### PR TITLE
fix: remove timeout from agent steps, add missing known fields (#2953)

### DIFF
--- a/src/adapters/cli_subprocess.rs
+++ b/src/adapters/cli_subprocess.rs
@@ -75,12 +75,14 @@ impl CLISubprocessAdapter {
         child_env
     }
 
-    /// Internal: spawn agent with optional system prompt and timeout.
-    fn execute_agent_step_with_timeout(
+    /// Internal: spawn agent with optional system prompt.
+    ///
+    /// Agent steps run without a timeout — they complete when the underlying
+    /// CLI process exits.
+    fn execute_agent_step_impl(
         &self,
         prompt: &str,
         system_prompt: Option<&str>,
-        timeout: Option<u64>,
         model: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         // Use a temp directory to avoid file races with the parent session (#2758)
@@ -123,44 +125,15 @@ impl CLISubprocessAdapter {
             .spawn()
             .with_context(|| format!("Failed to execute '{}'", self.cli))?;
 
-        let child_pid = child.id();
-
-        // Background heartbeat thread with timeout enforcement
+        // Background heartbeat thread for progress reporting
         let stop = Arc::new(AtomicBool::new(false));
-        let timed_out = Arc::new(AtomicBool::new(false));
         let stop_clone = stop.clone();
-        let timed_out_clone = timed_out.clone();
         let output_path = output_file.clone();
-        let deadline = timeout.map(|s| Instant::now() + Duration::from_secs(s));
 
         let heartbeat = std::thread::spawn(move || {
             let mut last_size = 0u64;
             let mut last_activity = Instant::now();
             while !stop_clone.load(Ordering::Relaxed) {
-                // Check timeout deadline
-                if let Some(dl) = deadline
-                    && Instant::now() >= dl
-                {
-                    eprintln!(
-                        "  [agent] TIMEOUT after {}s — killing process {}",
-                        timeout.unwrap_or(0),
-                        child_pid
-                    );
-                    timed_out_clone.store(true, Ordering::SeqCst);
-                    // Send SIGTERM via kill
-                    let _ = Command::new("kill")
-                        .args(["-15", &child_pid.to_string()])
-                        .output();
-                    // Give 5s grace, then SIGKILL only if process hasn't been stopped
-                    std::thread::sleep(Duration::from_secs(5));
-                    if !stop_clone.load(Ordering::SeqCst) {
-                        let _ = Command::new("kill")
-                            .args(["-9", &child_pid.to_string()])
-                            .output();
-                    }
-                    return;
-                }
-
                 if let Ok(meta) = std::fs::metadata(&output_path) {
                     let current_size = meta.len();
                     if current_size > last_size {
@@ -188,16 +161,6 @@ impl CLISubprocessAdapter {
         let status = child.wait()?;
         stop.store(true, Ordering::SeqCst);
         let _ = heartbeat.join();
-
-        if timed_out.load(Ordering::SeqCst) {
-            let partial = std::fs::read_to_string(&output_file).unwrap_or_default();
-            anyhow::bail!(
-                "Agent step timed out after {}s. Partial output ({} bytes): {}...",
-                timeout.unwrap_or(0),
-                partial.len(),
-                crate::safe_truncate(&partial, 500)
-            );
-        }
 
         let stdout = std::fs::read_to_string(&output_file).unwrap_or_default();
 
@@ -230,10 +193,9 @@ impl Adapter for CLISubprocessAdapter {
         system_prompt: Option<&str>,
         _mode: Option<&str>,
         _working_dir: &str,
-        timeout: Option<u64>,
         model: Option<&str>,
     ) -> Result<String, anyhow::Error> {
-        self.execute_agent_step_with_timeout(prompt, system_prompt, timeout, model)
+        self.execute_agent_step_impl(prompt, system_prompt, model)
     }
 
     fn execute_bash_step(

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -8,6 +8,9 @@ pub mod cli_subprocess;
 /// Adapters must be `Sync` to support parallel step execution via scoped threads.
 pub trait Adapter: Sync {
     /// Execute an agent step and return the output.
+    ///
+    /// Agent steps have no timeout — they run until the underlying CLI process
+    /// completes. Use the `timeout` field on bash steps for time-bounded work.
     #[allow(clippy::too_many_arguments)]
     fn execute_agent_step(
         &self,
@@ -16,11 +19,12 @@ pub trait Adapter: Sync {
         system_prompt: Option<&str>,
         mode: Option<&str>,
         working_dir: &str,
-        timeout: Option<u64>,
         model: Option<&str>,
     ) -> Result<String, anyhow::Error>;
 
     /// Execute a bash step and return the output.
+    ///
+    /// The optional `timeout` (in seconds) kills the process after the given duration.
     fn execute_bash_step(
         &self,
         command: &str,

--- a/src/models.rs
+++ b/src/models.rs
@@ -59,6 +59,8 @@ pub struct Step {
     pub parse_json_required: bool,
     pub mode: Option<String>,
     pub working_dir: Option<String>,
+    /// Timeout in seconds. Only applies to bash steps; agent steps run without
+    /// a timeout and complete when the underlying CLI process exits.
     pub timeout: Option<u64>,
     pub auto_stage: Option<bool>,
     pub recipe: Option<String>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,6 +44,8 @@ const KNOWN_STEP_FIELDS: &[&str] = &[
     "continue_on_error",
     "parallel_group",
     "when_tags",
+    "recovery_on_failure",
+    "model",
 ];
 
 #[derive(Debug, thiserror::Error)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -628,7 +628,6 @@ impl<A: Adapter> RecipeRunner<A> {
                         agent_system_prompt.as_deref(),
                         step.mode.as_deref(),
                         working_dir,
-                        step.timeout,
                         step.model.as_deref(),
                     )
                     .map_err(|e| StepExecutionError {
@@ -740,7 +739,6 @@ impl<A: Adapter> RecipeRunner<A> {
                     None,
                     None,
                     working_dir,
-                    step.timeout,
                     None,
                 ) {
                     Ok(output)
@@ -1005,7 +1003,6 @@ impl<A: Adapter> RecipeRunner<A> {
             None,
             None,
             working_dir,
-            step.timeout,
             None,
         ) {
             Ok(output) => Some(output),
@@ -1295,7 +1292,6 @@ mod tests {
             _system_prompt: Option<&str>,
             _mode: Option<&str>,
             _working_dir: &str,
-            _timeout: Option<u64>,
             _model: Option<&str>,
         ) -> Result<String, anyhow::Error> {
             Ok(format!(

--- a/tests/example_tests.rs
+++ b/tests/example_tests.rs
@@ -22,7 +22,6 @@ impl Adapter for MockAdapter {
         _system_prompt: Option<&str>,
         _mode: Option<&str>,
         _working_dir: &str,
-        _timeout: Option<u64>,
         _model: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         if prompt.contains("JSON") || prompt.contains("json") || prompt.contains("analyze") {
@@ -71,7 +70,6 @@ impl Adapter for FailOnExitAdapter {
         _: Option<&str>,
         _: Option<&str>,
         _: &str,
-        _: Option<u64>,
         _: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         Ok(format!("[mock-agent] {}", &prompt[..prompt.len().min(100)]))

--- a/tests/feature_tests.rs
+++ b/tests/feature_tests.rs
@@ -19,7 +19,6 @@ impl Adapter for MockAdapter {
         _: Option<&str>,
         _: Option<&str>,
         _: &str,
-        _: Option<u64>,
         _: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         if prompt.contains("FAIL") {
@@ -184,7 +183,6 @@ fn test_parse_json_success_returns_parsed_output() {
             _: Option<&str>,
             _: Option<&str>,
             _: &str,
-            _: Option<u64>,
             _: Option<&str>,
         ) -> Result<String, anyhow::Error> {
             Ok(r#"{"result": "success", "count": 42}"#.to_string())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -40,7 +40,6 @@ impl Adapter for MockAdapter {
         _system_prompt: Option<&str>,
         _mode: Option<&str>,
         _working_dir: &str,
-        _timeout: Option<u64>,
         _model: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         // Find matching response
@@ -503,7 +502,6 @@ steps:
             _s: Option<&str>,
             _m: Option<&str>,
             _w: &str,
-            _t: Option<u64>,
             _model: Option<&str>,
         ) -> Result<String, anyhow::Error> {
             Ok("ok".to_string())
@@ -726,7 +724,6 @@ fn test_model_parameter_passed_to_adapter() {
             _system_prompt: Option<&str>,
             _mode: Option<&str>,
             _working_dir: &str,
-            _timeout: Option<u64>,
             model: Option<&str>,
         ) -> Result<String, anyhow::Error> {
             self.captured_models

--- a/tests/recipe_tests.rs
+++ b/tests/recipe_tests.rs
@@ -80,7 +80,6 @@ impl Adapter for RecordingAdapter {
         _system_prompt: Option<&str>,
         _mode: Option<&str>,
         _working_dir: &str,
-        _timeout: Option<u64>,
         _model: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         self.agent_calls.fetch_add(1, Ordering::SeqCst);
@@ -1065,7 +1064,6 @@ fn test_unavailable_adapter_fails_gracefully() {
             _: Option<&str>,
             _: Option<&str>,
             _: &str,
-            _: Option<u64>,
             _: Option<&str>,
         ) -> Result<String, anyhow::Error> {
             Ok("".into())
@@ -2172,7 +2170,6 @@ impl Adapter for RecoverySuccessAdapter {
         _: Option<&str>,
         _: Option<&str>,
         _: &str,
-        _: Option<u64>,
         _: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         Ok("I fixed the issue. STATUS: COMPLETE".to_string())
@@ -2207,7 +2204,6 @@ impl Adapter for RecoveryFailAdapter {
         _: Option<&str>,
         _: Option<&str>,
         _: &str,
-        _: Option<u64>,
         _: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         Ok("I cannot fix this, the data is corrupt".to_string())


### PR DESCRIPTION
## Summary
- Remove `timeout` parameter from `Adapter::execute_agent_step` trait and all 12 implementations
- Remove deadline/SIGTERM/SIGKILL logic from heartbeat thread (keep progress reporting)
- Add `recovery_on_failure` and `model` to `KNOWN_STEP_FIELDS` validator whitelist
- Bash steps retain their optional timeout

## Problem
Agent steps can run for hours on complex tasks. The timeout mechanism killed them via SIGTERM/SIGKILL, causing silent failures and lost work. Additionally, the `recovery_on_failure` and `model` fields triggered spurious "unrecognized field" warnings during `--validate-only`.

## Test plan
- [x] All 287 tests pass (lib + 6 test binaries)
- [x] `--validate-only` on smart-orchestrator.yaml returns clean
- [x] Heartbeat progress reporting still works (no timeout kill logic)

Supersedes #2 (closed due to merge conflicts with main).
Fixes amplihack#2953

🤖 Generated with [Claude Code](https://claude.com/claude-code)