### PR TITLE
fix: align RealBashAdapter with updated Adapter trait signature

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -651,7 +651,6 @@ impl Adapter for RealBashAdapter {
         _system_prompt: Option<&str>,
         _mode: Option<&str>,
         _working_dir: &str,
-        _timeout: Option<u64>,
         _model: Option<&str>,
     ) -> Result<String, anyhow::Error> {
         Ok("mock agent response".to_string())


### PR DESCRIPTION
Removes timeout parameter from RealBashAdapter::execute_agent_step to match the trait change in ce9ee0e. Fixes Clippy and Build failures on main.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>