### PR TITLE
fix: quality audit cycle 3 - security hardening + configurability

### DIFF
--- a/src/agent_resolver.rs
+++ b/src/agent_resolver.rs
@@ -132,7 +132,11 @@ impl AgentResolver {
 
         Err(AgentResolveError::NotFound {
             agent_ref: agent_ref.to_string(),
-            searched: searched.join(", "),
+            searched: format!(
+                "{} director{} searched",
+                searched.len(),
+                if searched.len() == 1 { "y" } else { "ies" }
+            ),
         })
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -183,10 +183,16 @@ impl DiscoveryCache {
 /// Thread-safe convenience wrapper around [`DiscoveryCache`].
 ///
 /// Uses a module-level `Mutex<DiscoveryCache>` so callers don't need to manage
-/// their own cache instance.  The default TTL is 30 seconds.
+/// their own cache instance.  The TTL defaults to 30 seconds and can be
+/// overridden via the `RECIPE_RUNNER_CACHE_TTL` environment variable (in seconds).
 pub fn cached_discover_recipes(dirs: &[PathBuf]) -> HashMap<String, RecipeInfo> {
-    static CACHE: std::sync::LazyLock<Mutex<DiscoveryCache>> =
-        std::sync::LazyLock::new(|| Mutex::new(DiscoveryCache::new(Duration::from_secs(30))));
+    static CACHE: std::sync::LazyLock<Mutex<DiscoveryCache>> = std::sync::LazyLock::new(|| {
+        let ttl_secs: u64 = std::env::var("RECIPE_RUNNER_CACHE_TTL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(30);
+        Mutex::new(DiscoveryCache::new(Duration::from_secs(ttl_secs)))
+    });
 
     let mut cache = CACHE.lock().expect("DiscoveryCache mutex poisoned");
     cache.get_or_discover(dirs).clone()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -30,6 +30,9 @@ static JSON_FENCE_RE: LazyLock<Regex> =
 /// Maximum number of threads to spawn per parallel group.
 const MAX_PARALLEL_STEPS: usize = 50;
 
+/// Maximum size of step output stored in memory (10 MB).
+const MAX_STEP_OUTPUT_BYTES: usize = 10_000_000;
+
 /// Callback trait for step execution progress events.
 pub trait ExecutionListener {
     fn on_step_start(&self, step_id: &str, step_type: StepType) {
@@ -500,7 +503,19 @@ impl<A: Adapter> RecipeRunner<A> {
 
         // Execute the step
         let output = match self.dispatch_step(step, ctx) {
-            Ok(o) => o,
+            Ok(o) => {
+                if o.len() > MAX_STEP_OUTPUT_BYTES {
+                    warn!(
+                        "Step '{}' output truncated from {} to {} bytes",
+                        step.id,
+                        o.len(),
+                        MAX_STEP_OUTPUT_BYTES
+                    );
+                    crate::safe_truncate(&o, MAX_STEP_OUTPUT_BYTES).to_string()
+                } else {
+                    o
+                }
+            }
             Err(e) => {
                 error!("Step '{}' failed: {}", step.id, e);
                 return StepResult {


### PR DESCRIPTION
## Quality Audit - Cycle 3

### Security Hardening
- **sec-2**: Step output capped at `MAX_STEP_OUTPUT_BYTES` (10 MB) to prevent OOM from malicious recipes
- **sec-5**: `AgentResolveError::NotFound` no longer leaks internal directory paths — shows count only

### Configurability
- **dep-2**: Discovery cache TTL now configurable via `RECIPE_RUNNER_CACHE_TTL` env var (default: 30s)

### Verification
- 306 tests pass
- Clippy clean
- Format clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>