### PR TITLE
test: add 13 outside-in tests for quality audit cycle 3-4 features

### DIFF
--- a/tests/outside_in_tests.rs
+++ b/tests/outside_in_tests.rs
@@ -856,20 +856,14 @@ steps:
     command: "echo audited"
 "#,
     );
-    let (code, _stdout, _stderr) = run_binary(
-        &recipe,
-        &["--audit-dir", audit_dir.to_str().unwrap()],
-    );
+    let (code, _stdout, _stderr) =
+        run_binary(&recipe, &["--audit-dir", audit_dir.to_str().unwrap()]);
     assert_eq!(code, 0);
     // Audit dir should contain a .jsonl file
     let entries: Vec<_> = std::fs::read_dir(&audit_dir)
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .is_some_and(|ext| ext == "jsonl")
-        })
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "jsonl"))
         .collect();
     assert!(
         !entries.is_empty(),
@@ -879,7 +873,10 @@ steps:
     let content = std::fs::read_to_string(entries[0].path()).unwrap();
     for line in content.lines() {
         let parsed: Result<Value, _> = serde_json::from_str(line);
-        assert!(parsed.is_ok(), "each JSONL line should be valid JSON: {line}");
+        assert!(
+            parsed.is_ok(),
+            "each JSONL line should be valid JSON: {line}"
+        );
     }
 }
 
@@ -907,11 +904,15 @@ steps:
     let (code, json, _) = run_json(&recipe, &[]);
     assert_eq!(code, 0);
     assert_eq!(
-        find_step(&json, "guarded").unwrap()["status"].as_str().unwrap(),
+        find_step(&json, "guarded").unwrap()["status"]
+            .as_str()
+            .unwrap(),
         "skipped"
     );
     assert_eq!(
-        find_step(&json, "default-step").unwrap()["status"].as_str().unwrap(),
+        find_step(&json, "default-step").unwrap()["status"]
+            .as_str()
+            .unwrap(),
         "completed"
     );
 
@@ -919,11 +920,15 @@ steps:
     let (code, json, _) = run_json(&recipe, &["--set", "mode=custom"]);
     assert_eq!(code, 0);
     assert_eq!(
-        find_step(&json, "guarded").unwrap()["status"].as_str().unwrap(),
+        find_step(&json, "guarded").unwrap()["status"]
+            .as_str()
+            .unwrap(),
         "completed"
     );
     assert_eq!(
-        find_step(&json, "default-step").unwrap()["status"].as_str().unwrap(),
+        find_step(&json, "default-step").unwrap()["status"]
+            .as_str()
+            .unwrap(),
         "skipped"
     );
 }
@@ -1026,7 +1031,10 @@ steps:
         .env("RECIPE_RUNNER_CACHE_TTL", "5")
         .output()
         .expect("failed to execute");
-    assert!(output.status.success(), "binary should accept RECIPE_RUNNER_CACHE_TTL env var");
+    assert!(
+        output.status.success(),
+        "binary should accept RECIPE_RUNNER_CACHE_TTL env var"
+    );
 }
 
 /// User lists recipes via the `list` subcommand.


### PR DESCRIPTION
## Outside-In Test Coverage for Cycles 3 & 4

Adds 13 new outside-in tests covering user-facing behaviors from quality audit cycles 3 and 4.

### Tests Added
| # | Test | Feature |
|---|------|---------|
| 1 | `test_error_chain_context_in_step_failure` | err-9: error chain context preserved |
| 2 | `test_explain_mode_shows_recipe_structure` | --explain flag |
| 3 | `test_version_flag` | --version flag |
| 4 | `test_include_tags_filters_steps` | --include-tags filtering |
| 5 | `test_exclude_tags_skips_steps` | --exclude-tags filtering |
| 6 | `test_audit_dir_creates_log_file` | --audit-dir JSONL logging |
| 7 | `test_context_override_with_condition` | --set context override |
| 8 | `test_condition_with_builtin_functions` | len(), strip(), lower() |
| 9 | `test_falsy_condition_skips_step` | Falsy condition evaluation |
| 10 | `test_cache_ttl_env_var_accepted` | RECIPE_RUNNER_CACHE_TTL |
| 11 | `test_list_subcommand` | list subcommand |
| 12 | `test_output_chaining_between_steps` | Output variable chaining |
| 13 | `test_hooks_pre_and_post_step` | Pre/post step hooks |

### Test Counts
- Outside-in tests: **29** (up from 16)
- Total tests: **369** (up from 356)

### Methodology
Generated using outside-in testing methodology — every test invokes the compiled binary as a user would, with recipe YAML files and CLI flags, verifying stdout/stderr/exit-code behavior.

Part of quality audit issue #9.