### PR TITLE
improve: test gaps, CI coverage, docs for new features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,12 @@ jobs:
               missing=1
             fi
           done
+          # Submodules extracted from runner.rs
+          for mod in listeners json_parser audit; do
+            if ! grep -q "$mod" recipes/build-recipe-runner.yaml; then
+              echo "WARNING: recipes/build-recipe-runner.yaml missing reference to submodule $mod"
+            fi
+          done
           if [ "$missing" -eq 1 ]; then
             echo "Self-building recipe is out of sync with source modules"
             exit 1
@@ -110,3 +116,39 @@ jobs:
         run: cargo install cargo-audit --quiet
       - name: Run security audit
         run: cargo audit
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --quiet
+
+      - name: Run coverage
+        run: cargo tarpaulin --all-targets --out stdout --skip-clean 2>&1 | tee coverage.txt
+
+      - name: Check coverage threshold
+        run: |
+          # Extract coverage percentage
+          coverage=$(grep -oP '\d+\.\d+%' coverage.txt | tail -1 | tr -d '%')
+          echo "Coverage: ${coverage}%"
+          # Fail if below 60% (generous threshold to start)
+          if [ "$(echo "$coverage < 60" | bc)" -eq 1 ]; then
+            echo "ERROR: Coverage ${coverage}% is below 60% threshold"
+            exit 1
+          fi
+          echo "Coverage ${coverage}% meets threshold ✓"

--- a/docs/src/yaml-format.md
+++ b/docs/src/yaml-format.md
@@ -51,13 +51,15 @@ Hook commands receive context variables via template substitution.
 | `prompt`            | string          | no       | —       | Prompt template (agent steps)                            |
 | `output`            | string          | no       | —       | Variable name to store step output in context            |
 | `condition`         | string          | no       | —       | Expression that must be truthy to execute                |
-| `parse_json`        | bool            | no       | `false` | Extract JSON from step output                            |
+| `parse_json`          | bool            | no       | `false` | Extract JSON from step output                            |
+| `parse_json_required` | bool            | no       | `false` | Fail the step if JSON extraction fails (see below)       |
 | `mode`              | string          | no       | —       | Execution mode                                           |
 | `working_dir`       | string          | no       | —       | Override working directory for this step                 |
 | `timeout`           | int             | no       | —       | Step timeout in seconds                                  |
 | `auto_stage`        | bool            | no       | `true`  | Git auto-stage after agent steps                         |
 | `model`             | string          | no       | —       | Model override for agent steps (e.g., "haiku", "sonnet") |
 | `recipe`            | string          | no       | —       | Sub-recipe name (recipe steps)                           |
+| `recovery_on_failure` | bool            | no       | `false` | Attempt agentic recovery if sub-recipe fails (see below) |
 | `context`           | map             | no       | —       | Context overrides passed to sub-recipe                   |
 | `continue_on_error` | bool            | no       | `false` | Continue execution if this step fails                    |
 | `when_tags`         | list of strings | no       | `[]`    | Step only runs when these tags match active tag filters  |
@@ -186,6 +188,62 @@ If all strategies fail a warning is logged and the raw output is stored.
 
 - id: use-config
   command: echo "Region is {{api_config.region}}"
+```
+
+### Strict Mode (`parse_json_required`)
+
+By default, JSON extraction failure degrades the step (status becomes `degraded`)
+but the recipe continues. Set `parse_json_required: true` to make extraction
+failure a hard error that stops the recipe.
+
+```yaml
+- id: must-be-json
+  command: curl -s https://api.example.com/data
+  parse_json: true
+  parse_json_required: true  # fails the recipe if output isn't valid JSON
+  output: api_data
+```
+
+| `parse_json_required` | On extraction failure        |
+|-----------------------|------------------------------|
+| `false` (default)     | Step marked `degraded`, raw output stored, recipe continues |
+| `true`                | Step marked `failed`, recipe stops immediately |
+
+---
+
+## Sub-Recipe Recovery (`recovery_on_failure`)
+
+When a sub-recipe step fails, set `recovery_on_failure: true` to trigger an
+agentic recovery attempt. The runner sends the failure details to an agent,
+which attempts to complete the remaining work.
+
+```yaml
+- id: deploy
+  recipe: deploy-to-staging
+  recovery_on_failure: true  # agent attempts recovery if deploy fails
+```
+
+If the agent's recovery output contains "STATUS: COMPLETE" or "recovered",
+the step is marked as recovered and the recipe continues. Otherwise, the
+original failure propagates.
+
+---
+
+## Model Override (`model`)
+
+Agent steps can override the default model using the `model` field. The value
+is passed to the adapter, which maps it to a specific model identifier.
+
+```yaml
+- id: quick-check
+  agent: reviewer
+  prompt: "Quick lint check on {{file_path}}"
+  model: haiku  # fast, cheap model for simple tasks
+
+- id: deep-review
+  agent: reviewer
+  prompt: "Thorough security review of {{file_path}}"
+  model: sonnet  # more capable model for complex analysis
 ```
 
 ---

--- a/recipes/build-recipe-runner.yaml
+++ b/recipes/build-recipe-runner.yaml
@@ -391,21 +391,40 @@ steps:
     working_dir: "{{repo_path}}"
 
   # =========================================================================
-  # Phase 8 — runner.rs (Execution Engine)
+  # Phase 8 — runner/ module (Execution Engine, split into submodules)
   # =========================================================================
   - id: "create-runner"
     agent: "amplihack:core:builder"
     working_dir: "{{repo_path}}"
     prompt: |
-      Create src/runner.rs — the core execution engine (~1150 lines).
+      Create src/runner/ as a module directory with these files:
+      - src/runner/mod.rs — coordinator (~1140 lines)
+      - src/runner/listeners.rs — execution listeners (~55 lines)
+      - src/runner/json_parser.rs — JSON extraction (~150 lines)
+      - src/runner/audit.rs — audit logging (~55 lines)
 
-      ## ExecutionListener trait
+      ## src/runner/listeners.rs — ExecutionListener trait
       - on_step_start(step_id, step_type) — default no-op
       - on_step_complete(result) — default no-op
       - on_output(step_id, line) — default no-op
-      Implementations: NullListener (no-op), StderrListener (prints to stderr)
+      Implementations: NullListener (no-op), StderrListener (prints ▶ on start, ✓/✗/⊘/⚠ on complete)
 
-      ## RecipeRunner<A: Adapter> struct
+      ## src/runner/json_parser.rs — JSON extraction
+      Static JSON_FENCE_RE regex for ```json fences.
+      parse_json_output(output, step_id) -> Option<Value>
+      3 strategies: 1) direct parse, 2) markdown fence regex, 3) balanced braces
+      Include unit tests inline.
+
+      ## src/runner/audit.rs — JSONL audit logging
+      open_audit_log(audit_dir, recipe_name) -> Option<File>
+        Creates {recipe_name}-{unix_timestamp}.jsonl with mode 0600
+      write_audit_entry(file, result)
+        Writes JSON: step_id, status, duration_ms, error, output_len
+
+      ## src/runner/mod.rs — RecipeRunner<A: Adapter> coordinator
+      Re-exports: pub use listeners::{ExecutionListener, NullListener, StderrListener}
+      Internal use: use json_parser::parse_json_output
+
       Fields: adapter, agent_resolver (AgentResolver), working_dir,
       dry_run, auto_stage (default true), depth (Cell<u32>),
       total_steps (Cell<u32>), max_depth (Cell<u32>),
@@ -426,11 +445,11 @@ steps:
       2. Apply recursion limits from recipe.recursion
       3. Check depth <= max_depth, else error
       4. Merge recipe.context + user_context into RecipeContext
-      5. Create audit log file if audit_dir set
+      5. Create audit log file if audit_dir set (delegate to audit::open_audit_log)
       6. Group consecutive steps with same parallel_group
       7. For sequential steps: execute_single_step()
       8. For parallel groups: execute_parallel_group() using std::thread::scope
-      9. After each step: write audit entry, update context, check continue_on_error
+      9. After each step: write audit entry (delegate to audit::write_audit_entry), update context, check continue_on_error
       10. Return RecipeResult with timing
 
       ## execute_single_step (private)
@@ -439,28 +458,26 @@ steps:
       3. Evaluate condition (skip if false, fail if evaluation errors)
       4. Dry run: return mock output (mock JSON for parse_json steps)
       5. Dispatch by type: bash→adapter.execute_bash_step,
-         agent→adapter.execute_agent_step, recipe→execute_sub_recipe
-      6. If parse_json: try extract_json (3 strategies), retry once if failed
-      7. Store output in context
-      8. Git auto-stage after agent steps (git add -A)
-      9. Run post_step hook (or on_error hook on failure)
-      10. Return StepResult with timing
+         agent→adapter.execute_agent_step (with mode and model params),
+         recipe→execute_sub_recipe
+      6. If parse_json: try json_parser::parse_json_output, retry once if failed
+      7. If parse_json_required and extraction fails: mark step as Failed and stop recipe
+      8. Store output in context
+      9. Git auto-stage after agent steps (git add -A)
+      10. Run post_step hook (or on_error hook on failure)
+      11. Return StepResult with timing
 
       ## execute_sub_recipe (private)
       Check depth < max_depth. Find recipe by name. Parse it.
-      Create child RecipeRunner with depth+1. Execute. If failed, error.
-
-      ## extract_json (private static)
-      3 strategies: 1) direct parse, 2) markdown fence regex, 3) balanced braces
+      Create child RecipeRunner with depth+1. Execute.
+      If failed and recovery_on_failure is true: send failure details to agent for recovery.
+      If agent responds with "STATUS: COMPLETE" or "recovered": mark as recovered.
 
       ## execute_parallel_group (private)
       Use std::thread::scope. Only bash steps run in parallel threads.
       Non-bash steps fall back to sequential on main thread.
       Results collected in step order (not completion order) for determinism.
-
-      ## Audit log
-      JSONL format. Each entry: step_id, status, duration_ms, error, output_len.
-      One file per recipe run in audit_dir.
+      Thread panics caught and converted to Failed StepResult.
     output: "runner_done"
 
   - id: "verify-runner"

--- a/tests/outside_in_tests.rs
+++ b/tests/outside_in_tests.rs
@@ -1763,3 +1763,224 @@ steps:
         entry["duration_ms"]
     );
 }
+
+// ---------------------------------------------------------------------------
+// Model and mode field tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_model_field_in_dry_run_output() {
+    let tmp = TempDir::new().unwrap();
+    let recipe = write_recipe(
+        tmp.path(),
+        "model-field.yaml",
+        r#"
+name: model-test
+steps:
+  - id: with-model
+    agent: test-agent
+    prompt: "hello"
+    model: haiku
+"#,
+    );
+    let (code, json, _stderr) = run_json(&recipe, &["--dry-run"]);
+    assert_eq!(code, 0);
+    let step = find_step(&json, "with-model").expect("should find step");
+    // In dry-run, agent steps are skipped but the recipe parses successfully
+    assert!(
+        step["status"].as_str() == Some("skipped") || step["status"].as_str() == Some("degraded"),
+        "dry-run agent step should be skipped or degraded, got: {}",
+        step["status"]
+    );
+}
+
+#[test]
+fn test_mode_field_accepted_in_recipe() {
+    let tmp = TempDir::new().unwrap();
+    let recipe = write_recipe(
+        tmp.path(),
+        "mode-field.yaml",
+        r#"
+name: mode-test
+steps:
+  - id: with-mode
+    agent: test-agent
+    prompt: "hello"
+    mode: background
+"#,
+    );
+    // Should parse without error even with mode field
+    let (code, _stdout, _stderr) = run_binary(&recipe, &["--validate-only"]);
+    assert_eq!(code, 0, "recipe with mode field should validate");
+}
+
+#[test]
+fn test_model_and_mode_combined() {
+    let tmp = TempDir::new().unwrap();
+    let recipe = write_recipe(
+        tmp.path(),
+        "model-mode.yaml",
+        r#"
+name: model-mode-test
+steps:
+  - id: combined
+    agent: test-agent
+    prompt: "hello"
+    model: sonnet
+    mode: background
+"#,
+    );
+    let (code, _stdout, _stderr) = run_binary(&recipe, &["--validate-only"]);
+    assert_eq!(code, 0, "recipe with both model and mode should validate");
+}
+
+// ---------------------------------------------------------------------------
+// Parallel execution edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_parallel_group_with_failing_step() {
+    let tmp = TempDir::new().unwrap();
+    let recipe = write_recipe(
+        tmp.path(),
+        "parallel-fail.yaml",
+        r#"
+name: parallel-fail-test
+steps:
+  - id: para-ok
+    command: echo ok
+    parallel_group: g1
+  - id: para-fail
+    command: exit 1
+    parallel_group: g1
+    continue_on_error: true
+  - id: para-ok2
+    command: echo ok2
+    parallel_group: g1
+"#,
+    );
+    let (code, json, _stderr) = run_json(&recipe, &[]);
+    assert_eq!(code, 0, "recipe should succeed with continue_on_error");
+    let ok_step = find_step(&json, "para-ok").expect("para-ok should exist");
+    assert_eq!(ok_step["status"].as_str(), Some("completed"));
+    let fail_step = find_step(&json, "para-fail").expect("para-fail should exist");
+    assert!(
+        fail_step["status"].as_str() == Some("degraded")
+            || fail_step["status"].as_str() == Some("failed"),
+        "failed parallel step should be degraded or failed"
+    );
+    let ok2_step = find_step(&json, "para-ok2").expect("para-ok2 should exist");
+    assert_eq!(ok2_step["status"].as_str(), Some("completed"));
+}
+
+#[test]
+fn test_parallel_group_all_succeed() {
+    let tmp = TempDir::new().unwrap();
+    let recipe = write_recipe(
+        tmp.path(),
+        "parallel-ok.yaml",
+        r#"
+name: parallel-ok-test
+steps:
+  - id: p1
+    command: echo one
+    parallel_group: grp
+  - id: p2
+    command: echo two
+    parallel_group: grp
+  - id: p3
+    command: echo three
+    parallel_group: grp
+"#,
+    );
+    let (code, json, _stderr) = run_json(&recipe, &[]);
+    assert_eq!(code, 0);
+    // All 3 steps should complete
+    for id in &["p1", "p2", "p3"] {
+        let step = find_step(&json, id).unwrap_or_else(|| panic!("{id} should exist"));
+        assert_eq!(
+            step["status"].as_str(),
+            Some("completed"),
+            "{id} should complete"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// recovery_on_failure (sub-recipe feature)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_recovery_on_failure_field_parsed_in_recipe() {
+    let tmp = TempDir::new().unwrap();
+    let recipe = write_recipe(
+        tmp.path(),
+        "recovery.yaml",
+        r#"
+name: recovery-test
+steps:
+  - id: call-sub
+    recipe: nonexistent-recipe
+    recovery_on_failure: true
+"#,
+    );
+    // Should parse successfully even though sub-recipe doesn't exist
+    let (code, _stdout, _stderr) = run_binary(&recipe, &["--validate-only"]);
+    assert_eq!(code, 0, "recipe with recovery_on_failure should validate");
+}
+
+// ---------------------------------------------------------------------------
+// parse_json_required (strict JSON parsing)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_parse_json_required_fails_on_non_json() {
+    let tmp = TempDir::new().unwrap();
+    let recipe = write_recipe(
+        tmp.path(),
+        "strict-json.yaml",
+        r#"
+name: strict-json-test
+steps:
+  - id: strict
+    command: echo "this is not json"
+    parse_json: true
+    parse_json_required: true
+"#,
+    );
+    let (code, json, _stderr) = run_json(&recipe, &[]);
+    assert_ne!(
+        code, 0,
+        "parse_json_required should fail recipe on non-JSON"
+    );
+    let step = find_step(&json, "strict").expect("strict step should exist");
+    assert_eq!(
+        step["status"].as_str(),
+        Some("failed"),
+        "step should be failed when parse_json_required and output is not JSON"
+    );
+}
+
+#[test]
+fn test_parse_json_required_succeeds_on_valid_json() {
+    let tmp = TempDir::new().unwrap();
+    let recipe = write_recipe(
+        tmp.path(),
+        "strict-json-ok.yaml",
+        r#"
+name: strict-json-ok-test
+steps:
+  - id: strict-ok
+    command: 'echo ''{"valid": true}'''
+    parse_json: true
+    parse_json_required: true
+"#,
+    );
+    let (code, json, _stderr) = run_json(&recipe, &[]);
+    assert_eq!(
+        code, 0,
+        "parse_json_required with valid JSON should succeed"
+    );
+    let step = find_step(&json, "strict-ok").expect("step should exist");
+    assert_eq!(step["status"].as_str(), Some("completed"));
+}


### PR DESCRIPTION
## Summary

Addresses test coverage gaps, missing documentation, and CI improvements identified during quality audit.

### Tests (8 new outside-in tests)
- **model/mode fields**: Validation, dry-run, and combined usage
- **parallel execution**: Failing step with `continue_on_error`, all-succeed path
- **recovery_on_failure**: Field parsing validation
- **parse_json_required**: Strict mode fails on non-JSON, succeeds on valid JSON

### CI
- **Code coverage**: Added `cargo-tarpaulin` job with 60% threshold
- **Module check update**: Self-building recipe now checks runner submodules (listeners, json_parser, audit)

### Documentation (yaml-format.md)
- `parse_json_required`: Strict JSON extraction mode
- `recovery_on_failure`: Agentic sub-recipe recovery
- `model`: Agent step model override
- Updated step fields table with both new fields

### Self-Building Recipe
- Updated Phase 8 for runner/ module directory (4 submodules)
- Added `parse_json_required`, `recovery_on_failure`, `model`, `mode` to specs

### Test counts
- Outside-in: 51 → 59
- Total: 399 → 407