### PR TITLE
fix(discovery): find recipes in ~/.amplihack/amplifier-bundle/recipes

### DIFF
--- a/src/condition.rs
+++ b/src/condition.rs
@@ -630,13 +630,8 @@ fn apply_function(name: &str, args: &[Value]) -> Result<Value, ConditionError> {
                         crate::safe_truncate(s, 50)
                     ))
                 })?,
-                Value::Bool(b) => {
-                    if *b {
-                        1
-                    } else {
-                        0
-                    }
-                }
+                Value::Bool(true) => 1,
+                Value::Bool(false) => 0,
                 _ => 0,
             };
             Ok(Value::Number(serde_json::Number::from(n)))
@@ -651,13 +646,8 @@ fn apply_function(name: &str, args: &[Value]) -> Result<Value, ConditionError> {
                         crate::safe_truncate(s, 50)
                     ))
                 })?,
-                Value::Bool(b) => {
-                    if *b {
-                        1.0
-                    } else {
-                        0.0
-                    }
-                }
+                Value::Bool(true) => 1.0,
+                Value::Bool(false) => 0.0,
                 _ => 0.0,
             };
             Ok(serde_json::Number::from_f64(n)

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -50,7 +50,9 @@ fn default_search_dirs() -> Vec<PathBuf> {
     }
     dirs.extend([
         // Installed amplihack bundle (current layout)
-        home.join(".amplihack").join("amplifier-bundle").join("recipes"),
+        home.join(".amplihack")
+            .join("amplifier-bundle")
+            .join("recipes"),
         // Legacy installed location (kept for back-compat)
         home.join(".amplihack").join(".claude").join("recipes"),
         // Project-local layouts

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -49,7 +49,11 @@ fn default_search_dirs() -> Vec<PathBuf> {
         }
     }
     dirs.extend([
+        // Installed amplihack bundle (current layout)
+        home.join(".amplihack").join("amplifier-bundle").join("recipes"),
+        // Legacy installed location (kept for back-compat)
         home.join(".amplihack").join(".claude").join("recipes"),
+        // Project-local layouts
         PathBuf::from("amplifier-bundle").join("recipes"),
         PathBuf::from("src")
             .join("amplihack")
@@ -239,6 +243,11 @@ pub fn find_recipe(name: &str, search_dirs: Option<&[PathBuf]>) -> Option<PathBu
 /// Verify that global recipe directories exist and contain recipes.
 pub fn verify_global_installation() -> serde_json::Value {
     let global_dirs = vec![
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".amplihack")
+            .join("amplifier-bundle")
+            .join("recipes"),
         dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join(".amplihack")

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -307,7 +307,7 @@ impl<A: Adapter> RecipeRunner<A> {
                     self.execute_parallel_group(&group_steps, recipe, &ctx, &*self.listener);
 
                 let mut group_failed = false;
-                for (gs, result) in group_steps.iter().zip(group_results.into_iter()) {
+                for (gs, result) in group_steps.iter().zip(group_results) {
                     self.total_steps.set(self.total_steps.get() + 1);
                     let failed = result.status == StepStatus::Failed;
 


### PR DESCRIPTION
## Summary

Fixes rysweet/amplihack#4392.

`default_search_dirs()` and `verify_global_installation()` looked in `~/.amplihack/.claude/recipes` (the legacy layout, which no longer exists) plus a CWD-relative `amplifier-bundle/recipes`. The current installed layout puts recipes under `~/.amplihack/amplifier-bundle/recipes`. As a result:

- Top-level recipes only resolved when invoked with an absolute path
- Sub-recipe lookup (e.g. `smart-orchestrator` → `default-workflow`) failed with `Sub-recipe 'default-workflow' not found` from any directory other than `~/.amplihack` itself

## Repro before fix

```bash
cd /tmp/some-other-dir
amplihack recipe run $HOME/.amplihack/amplifier-bundle/recipes/smart-orchestrator.yaml \
  -c task_description='anything' -c repo_path='.'
# → step-execute-single-round-1-development fails with:
#   Sub-recipe 'default-workflow' not found
```

## Fix

Add `~/.amplihack/amplifier-bundle/recipes` to the front of `default_search_dirs()` and to `verify_global_installation()`'s `global_dirs`. Keep the legacy `~/.amplihack/.claude/recipes` entry for back-compat.

## Tests

`cargo test --release` — all 95 unit tests pass. No new tests added because `default_search_dirs()` is an internal helper that's hard to test without mocking `dirs::home_dir()`; the discovery test suite exercises the real `find_recipe()` flow with explicit `search_dirs`, which is unchanged.