### PR TITLE
ci: ignore RUSTSEC-2026-0097 (transitive dev-dep via proptest)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+# cargo-audit configuration
+# https://github.com/rustsec/rustsec/tree/main/cargo-audit
+
+[advisories]
+ignore = [
+    # RUSTSEC-2026-0097: rand 0.9.x unsound with custom logger using rand::rng.
+    # Transitive dev-dependency via proptest 1.10.0. No production impact.
+    # Pending upstream proptest update to a patched rand version.
+    "RUSTSEC-2026-0097",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1154,7 +1154,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes the failing Security Audit CI check from PR #82.

**Advisory**: RUSTSEC-2026-0097 — rand 0.9.2 is unsound with custom logger using `rand::rng`.

**Root cause**: `rand 0.9.2` is a transitive dev-dependency pulled in by `proptest 1.10.0`. It has no production impact and the unsound behavior requires custom loggers which our test suite doesn't use.

**Fix**: Add `.cargo/audit.toml` with an ignore entry for this advisory until proptest ships with a patched rand version.