### PR TITLE
fix(condition): support postfix access in call args; v0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "recipe-runner-rs"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recipe-runner-rs"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 description = "Code-enforced YAML workflow execution engine for amplihack"
 license = "MIT"

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1221,10 +1221,7 @@ mod tests {
     #[test]
     fn test_quality_audit_validated_findings_missing_key() {
         // Same condition shape, but the key is absent — must evaluate to false (not error).
-        let data = ctx(&[(
-            "validated_findings",
-            json!({"rejected_count": 1}),
-        )]);
+        let data = ctx(&[("validated_findings", json!({"rejected_count": 1}))]);
         assert!(
             !evaluate_condition(
                 "validated_findings and validated_findings['confirmed_count'] > 0",
@@ -1268,17 +1265,13 @@ mod tests {
     #[test]
     fn test_list_literal_in_operator_match() {
         let data = ctx(&[("task_type", json!("feature"))]);
-        assert!(
-            evaluate_condition("task_type in ['feature', 'bug']", &data).unwrap()
-        );
+        assert!(evaluate_condition("task_type in ['feature', 'bug']", &data).unwrap());
     }
 
     #[test]
     fn test_list_literal_in_operator_no_match() {
         let data = ctx(&[("task_type", json!("chore"))]);
-        assert!(
-            !evaluate_condition("task_type in ['feature', 'bug']", &data).unwrap()
-        );
+        assert!(!evaluate_condition("task_type in ['feature', 'bug']", &data).unwrap());
     }
 
     #[test]
@@ -1290,18 +1283,14 @@ mod tests {
             ("name", json!("alpha-beta")),
             ("prefixes", json!({"default": "alpha"})),
         ]);
-        assert!(
-            evaluate_condition("name.startswith(prefixes['default'])", &data).unwrap()
-        );
+        assert!(evaluate_condition("name.startswith(prefixes['default'])", &data).unwrap());
     }
 
     #[test]
     fn test_postfix_dot_access_inside_function_call_arg() {
         // Same regression for dot-property access on a function argument.
         let data = ctx(&[("config", json!({"items": [1, 2, 3]}))]);
-        assert!(
-            evaluate_condition("len(config.items) == 3", &data).unwrap()
-        );
+        assert!(evaluate_condition("len(config.items) == 3", &data).unwrap());
     }
 
     #[test]

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -358,9 +358,15 @@ impl<'a> ExprParser<'a> {
     //        | '[' STRING ']'         (object key access)
     //        | '[' NUMBER ']'         (array index access)
     fn parse_primary(&mut self) -> Result<Value, ConditionError> {
-        let mut value = self.parse_atom()?;
+        let value = self.parse_atom()?;
+        self.parse_postfix_chain(value)
+    }
 
-        // Handle postfix access and method calls.
+    /// Apply the postfix access chain (`.field`, `.method(...)`, `['k']`, `[i]`)
+    /// to an already-parsed value. Shared by `parse_primary` and `parse_or_value`
+    /// so method/function-call arguments support the same postfix syntax as
+    /// top-level expressions (e.g. `obj.contains(items['key'])`).
+    fn parse_postfix_chain(&mut self, mut value: Value) -> Result<Value, ConditionError> {
         loop {
             match self.peek() {
                 Some(Token::Dot) => {
@@ -498,9 +504,12 @@ impl<'a> ExprParser<'a> {
         Ok(accessed)
     }
 
-    /// Parse an expression that returns a Value (for function/method args)
+    /// Parse an expression that returns a Value (for function/method args).
+    /// Includes the postfix chain so arguments may use `.field` / `['k']` /
+    /// `[i]` accessors (e.g. `obj.contains(items['key'])`).
     fn parse_or_value(&mut self) -> Result<Value, ConditionError> {
-        self.parse_atom()
+        let value = self.parse_atom()?;
+        self.parse_postfix_chain(value)
     }
 
     // atom: STRING | NUMBER | IDENT | function_call | '(' or_expr ')'
@@ -588,8 +597,8 @@ impl<'a> ExprParser<'a> {
                 Ok(Value::Array(items))
             }
             Some(tok) => Err(ConditionError::Parse(format!(
-                "unexpected token: {:?}",
-                tok
+                "unexpected token: {:?} at position {}",
+                tok, self.pos
             ))),
             None => Err(ConditionError::Parse(
                 "unexpected end of expression".to_string(),
@@ -1183,5 +1192,129 @@ mod tests {
     fn test_bracket_access_array_index() {
         let data = ctx(&[("items", json!(["alpha", "beta"]))]);
         assert!(evaluate_condition("items[1] == 'beta'", &data).unwrap());
+    }
+
+    // -- Regression: condition parser bug (amplihack#4398, amplihack-rs#313) --
+    //
+    // These tests cover four scenario categories from the failing recipes:
+    //   1. quality-audit-cycle.yaml — `validated_findings and validated_findings['confirmed_count'] > 0`
+    //   2. default-workflow.yaml step-07-write-tests — chained `!=` with `and`
+    //   3. List literals as RHS of `in` operator
+    //   4. Postfix bracket/dot access on values used as method/function call arguments
+
+    #[test]
+    fn test_quality_audit_validated_findings_present() {
+        // From quality-audit-cycle.yaml: bracket access on object value combined with `and`.
+        let data = ctx(&[(
+            "validated_findings",
+            json!({"confirmed_count": 3, "rejected_count": 1}),
+        )]);
+        assert!(
+            evaluate_condition(
+                "validated_findings and validated_findings['confirmed_count'] > 0",
+                &data,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_quality_audit_validated_findings_missing_key() {
+        // Same condition shape, but the key is absent — must evaluate to false (not error).
+        let data = ctx(&[(
+            "validated_findings",
+            json!({"rejected_count": 1}),
+        )]);
+        assert!(
+            !evaluate_condition(
+                "validated_findings and validated_findings['confirmed_count'] > 0",
+                &data,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_default_workflow_step07_resume_checkpoint_true() {
+        // From default-workflow.yaml step-07-write-tests — true case (no resume checkpoint set).
+        let data = ctx(&[("resume_checkpoint", json!(""))]);
+        assert!(
+            evaluate_condition(
+                "resume_checkpoint != 'checkpoint-after-implementation' and \
+                 resume_checkpoint != 'checkpoint-after-review-feedback'",
+                &data,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_default_workflow_step07_resume_checkpoint_false() {
+        // Same condition, false case — resume_checkpoint matches one disallowed value.
+        let data = ctx(&[(
+            "resume_checkpoint",
+            json!("checkpoint-after-implementation"),
+        )]);
+        assert!(
+            !evaluate_condition(
+                "resume_checkpoint != 'checkpoint-after-implementation' and \
+                 resume_checkpoint != 'checkpoint-after-review-feedback'",
+                &data,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_list_literal_in_operator_match() {
+        let data = ctx(&[("task_type", json!("feature"))]);
+        assert!(
+            evaluate_condition("task_type in ['feature', 'bug']", &data).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_list_literal_in_operator_no_match() {
+        let data = ctx(&[("task_type", json!("chore"))]);
+        assert!(
+            !evaluate_condition("task_type in ['feature', 'bug']", &data).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_postfix_bracket_access_inside_method_call_arg() {
+        // Regression: `parse_or_value` previously called `parse_atom` directly,
+        // so postfix `['k']` on a method/function argument would not parse and
+        // produced "unexpected token: LBracket". Now it must parse and evaluate.
+        let data = ctx(&[
+            ("name", json!("alpha-beta")),
+            ("prefixes", json!({"default": "alpha"})),
+        ]);
+        assert!(
+            evaluate_condition("name.startswith(prefixes['default'])", &data).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_postfix_dot_access_inside_function_call_arg() {
+        // Same regression for dot-property access on a function argument.
+        let data = ctx(&[("config", json!({"items": [1, 2, 3]}))]);
+        assert!(
+            evaluate_condition("len(config.items) == 3", &data).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_unexpected_lbracket_error_includes_position() {
+        // The catch-all `parse_atom` error must mention "position" so future
+        // condition-parser bugs are easier to localize from logs.
+        let data: HashMap<String, Value> = HashMap::new();
+        let err = evaluate_condition("== ['a']", &data).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("position"),
+            "expected error message to mention token position, got: {}",
+            msg
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the recipe condition parser so postfix access (`.field`, `['k']`, `[i]`, `.method()`) works inside method/function call arguments. Bumps version 0.3.4 → 0.3.5.

## Root cause

The reported `Parse error: unexpected token: LBracket` symptom in rysweet/amplihack-rs#313 and rysweet/amplihack#4398 reproduces against pre-#71/#81 binaries — those releases predate primary-position bracket access and list literals. All four candidate failing conditions (default-workflow step-07-write-tests, quality-audit-cycle validated_findings, etc.) parse cleanly on `main`. Consumers should bump to v0.3.5+.

While auditing, one real gap remained: `parse_or_value` (used for call arguments) called bare `parse_atom` and skipped the postfix loop, so `obj.contains(items['key'])` failed with `expected ')'`. This PR closes that gap.

## Changes

- **`src/condition.rs`**:
  - Extract postfix loop from `parse_primary` into shared `parse_postfix_chain` helper (pure refactor).
  - Wire `parse_or_value` through `parse_postfix_chain` so call args support `.field` / `['k']` / `[i]` / `.method()`.
  - Include token position in the catch-all `unexpected token` error from `parse_atom` for easier future debugging.
  - Add 8 regression tests (validated_findings present/missing, step-07 chain true/false, list literal in/out, postfix-on-call-arg bracket + dot, error includes position).
- **`Cargo.toml`**: 0.3.4 → 0.3.5.

## Verification

- `cargo test --lib`: **230 passed, 0 failed**
- `cargo clippy --all-targets -- -D warnings`: **clean**
- TDD: 2 of 8 new tests failed before the source change (`test_postfix_bracket_access_inside_method_call_arg`, `test_unexpected_lbracket_error_includes_position`); all 8 pass after.

## Related

- rysweet/amplihack-rs#313
- rysweet/amplihack#4398
- Builds on #71 (bracket access) and #81 (list literals)

## Out of scope

- No recipe YAML changes.
- No broader parser refactor.
- Consumer version-bump PRs will follow once this merges and v0.3.5 is tagged.