### PR TITLE
fix: cluster of 6 discovery/runner code-quality bugs (#42 #43 #44 #45 #46 #47)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/adapters/cli_subprocess.rs
+++ b/src/adapters/cli_subprocess.rs
@@ -9,8 +9,10 @@ use crate::adapters::Adapter;
 use anyhow::Context;
 use std::collections::HashMap;
 use std::env;
+use std::io::Read;
 use std::io::Write;
 use std::io::{BufRead, BufReader};
+use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -26,6 +28,25 @@ const RECIPE_CHILD_NO_REENTRY_SYSTEM_PROMPT: &str = "You are already inside an a
 const MAX_INLINE_AGENT_PROMPT_BYTES: usize = 32 * 1024;
 const FILE_BACKED_INLINE_PROMPT_BYTES: usize = 8 * 1024;
 const FILE_BACKED_PROMPT_CONTINUATION_NOTE: &str = "\n\nIMPORTANT: Additional task instructions, output requirements, and context continue in the appended system prompt. Treat that appended content as part of this same request and follow it fully.";
+
+/// Read at most `max_bytes + 1` bytes from `path`, returning UTF-8 (lossy).
+///
+/// The `+1` is a sentinel: callers can detect overflow when the returned
+/// length exceeds `max_bytes` and apply their own truncation/warning policy
+/// (see [`crate::runner::MAX_STEP_OUTPUT_BYTES`]). This caps agent-output
+/// memory growth at a fixed bound regardless of how large the on-disk file
+/// is, defending against runaway processes that produce multi-GB output.
+///
+/// Errors propagate from `File::open` (e.g. NotFound, PermissionDenied) so
+/// callers can decide whether to retry or fall back. UTF-8 errors do not
+/// fail; invalid sequences are replaced with U+FFFD.
+pub(crate) fn read_capped(path: &Path, max_bytes: usize) -> std::io::Result<String> {
+    let file = std::fs::File::open(path)?;
+    let cap = max_bytes.saturating_add(1);
+    let mut buf = Vec::with_capacity(std::cmp::min(cap, 64 * 1024));
+    file.take(cap as u64).read_to_end(&mut buf)?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
 
 pub struct CLISubprocessAdapter {
     cli: String,
@@ -456,7 +477,11 @@ impl CLISubprocessAdapter {
         // Read agent output with retry and graceful fallback (#3740).
         // The output file can be missing if: the temp dir was cleaned by the OS,
         // the agent crashed before writing, or a race condition on fast exits.
-        let stdout = match std::fs::read_to_string(&output_file) {
+        // Bounded read at MAX_STEP_OUTPUT_BYTES + 1 (#47): protects against
+        // unbounded memory growth from runaway agent processes; the runner
+        // detects len > MAX and applies safe_truncate as the final policy step.
+        let max_out = crate::runner::MAX_STEP_OUTPUT_BYTES;
+        let stdout = match read_capped(&output_file, max_out) {
             Ok(content) => content,
             Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {
                 log::warn!(
@@ -464,7 +489,7 @@ impl CLISubprocessAdapter {
                     output_file.display()
                 );
                 std::thread::sleep(std::time::Duration::from_secs(1));
-                match std::fs::read_to_string(&output_file) {
+                match read_capped(&output_file, max_out) {
                     Ok(content) => {
                         log::info!("Agent output file found on retry");
                         content
@@ -687,6 +712,69 @@ mod tests {
                 }
             }
         }
+    }
+
+    // ── #47: read_capped enforces MAX+1 byte cap on agent output ──────
+
+    #[test]
+    fn test_read_capped_returns_full_content_under_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("small.txt");
+        let payload = "hello world";
+        std::fs::write(&path, payload).unwrap();
+        let out = read_capped(&path, 1024).expect("small read must succeed");
+        assert_eq!(out, payload);
+    }
+
+    #[test]
+    fn test_read_capped_caps_at_max_plus_one_byte() {
+        // Writes a file > MAX bytes; read_capped must return AT MOST MAX+1
+        // bytes of UTF-8 (the +1 is the sentinel that signals "overflow").
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("big.txt");
+        let max = 1024usize;
+        let oversize = max + 5000;
+        let payload = vec![b'x'; oversize];
+        std::fs::write(&path, &payload).unwrap();
+        let out = read_capped(&path, max).expect("read must not error on oversize");
+        assert!(
+            out.len() <= max + 1,
+            "read_capped returned {} bytes, must be <= MAX+1 ({})",
+            out.len(),
+            max + 1
+        );
+        assert!(
+            out.len() > max,
+            "read_capped returned {} bytes, must exceed MAX so caller can detect truncation",
+            out.len()
+        );
+    }
+
+    #[test]
+    fn test_read_capped_missing_file_propagates_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nonexistent.txt");
+        assert!(read_capped(&path, 1024).is_err());
+    }
+
+    #[test]
+    fn test_read_capped_at_agent_output_limit_is_truncated() {
+        // Integration-style: write >MAX_STEP_OUTPUT_BYTES and confirm the
+        // bounded reader caps memory growth at the runner's limit.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("agent.out");
+        // Use 11 MB written in chunks to avoid a 10MB+ Vec literal.
+        let max = crate::runner::MAX_STEP_OUTPUT_BYTES;
+        let chunk = vec![b'a'; 1_000_000];
+        {
+            use std::io::Write;
+            let mut f = std::fs::File::create(&path).unwrap();
+            for _ in 0..(max / chunk.len() + 1) {
+                f.write_all(&chunk).unwrap();
+            }
+        }
+        let out = read_capped(&path, max).unwrap();
+        assert!(out.len() <= max + 1, "must cap at MAX+1; got {}", out.len());
     }
 
     #[test]

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -344,6 +344,77 @@ pub fn check_upstream_changes(local_dir: Option<&Path>) -> Vec<HashMap<String, S
     changes
 }
 
+/// Default upstream URL used when `RECIPE_RUNNER_UPSTREAM_URL` is not set.
+pub const DEFAULT_UPSTREAM_URL: &str = "https://github.com/microsoft/amplifier-bundle-recipes";
+
+/// Environment variable that overrides the upstream sync URL.
+pub const UPSTREAM_URL_ENV: &str = "RECIPE_RUNNER_UPSTREAM_URL";
+
+/// Resolve the upstream URL from the environment (or default) with validation.
+///
+/// Reads `RECIPE_RUNNER_UPSTREAM_URL`; falls back to [`DEFAULT_UPSTREAM_URL`].
+/// Validates that the URL uses an `http://` or `https://` scheme and does NOT
+/// embed userinfo (e.g. `https://user:secret@host/...`). Error messages do not
+/// echo the raw value, to avoid leaking credentials into logs.
+pub fn upstream_url() -> Result<String, anyhow::Error> {
+    upstream_url_inner(|k| std::env::var(k).ok())
+}
+
+/// Pure inner helper for [`upstream_url`] that takes an env-lookup closure.
+///
+/// Exposed for testability so unit tests do not have to mutate global env.
+pub fn upstream_url_inner<F>(get_env: F) -> Result<String, anyhow::Error>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let raw = get_env(UPSTREAM_URL_ENV).unwrap_or_else(|| DEFAULT_UPSTREAM_URL.to_string());
+    validate_upstream_url(&raw)?;
+    Ok(raw)
+}
+
+/// Validate that a URL is acceptable for upstream sync.
+///
+/// Rules:
+///   * Must be non-empty.
+///   * Scheme must be `http://` or `https://` (case-insensitive).
+///   * Must NOT contain userinfo (`user:pass@host`).
+///
+/// Errors are intentionally generic and do not include the raw URL value.
+fn validate_upstream_url(raw: &str) -> Result<(), anyhow::Error> {
+    if raw.is_empty() {
+        return Err(anyhow::anyhow!(
+            "upstream URL is empty (set {} or unset to use the default)",
+            UPSTREAM_URL_ENV
+        ));
+    }
+    let lower = raw.to_ascii_lowercase();
+    let scheme_end = match lower.find("://") {
+        Some(i) => i,
+        None => {
+            return Err(anyhow::anyhow!(
+                "upstream URL is missing a scheme; only http:// and https:// are accepted"
+            ));
+        }
+    };
+    let scheme = &lower[..scheme_end];
+    if scheme != "http" && scheme != "https" {
+        return Err(anyhow::anyhow!(
+            "upstream URL has an unsupported scheme; only http:// and https:// are accepted"
+        ));
+    }
+    let after_scheme = &raw[scheme_end + 3..];
+    let authority_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    let authority = &after_scheme[..authority_end];
+    if authority.contains('@') {
+        return Err(anyhow::anyhow!(
+            "upstream URL must not embed credentials (userinfo); use a credential helper instead"
+        ));
+    }
+    Ok(())
+}
+
 /// Write a manifest file recording the current hash of each recipe.
 pub fn update_manifest(local_dir: Option<&Path>) -> Result<PathBuf, std::io::Error> {
     let recipe_dir = local_dir
@@ -383,7 +454,8 @@ pub fn sync_upstream(
     branch: Option<&str>,
     remote_name: Option<&str>,
 ) -> Result<serde_json::Value, anyhow::Error> {
-    let repo = repo_url.unwrap_or("https://github.com/microsoft/amplifier-bundle-recipes");
+    let default_url = upstream_url()?;
+    let repo = repo_url.unwrap_or(&default_url);
     let br = branch.unwrap_or("main");
     let remote = format!("upstream-{}", remote_name.unwrap_or("amplifier-recipes"));
 
@@ -814,16 +886,6 @@ steps:
         }
     }
 
-    // ── #45: verify_global_installation must be removed ────────────────
-
-    /// Compile-time guarantee: verify_global_installation no longer exists.
-    /// If this module compiles after removal, the symbol is gone.
-    #[test]
-    fn test_verify_global_installation_removed() {
-        // Intentionally empty — the surrounding cfg(test) module will fail
-        // to compile if any code references the deleted function.
-    }
-
     // ── #42: find_recipe + discover_recipes must support .yml ──────────
 
     #[test]
@@ -893,6 +955,85 @@ steps:
                 bad
             );
         }
+    }
+
+    // ── #46: upstream_url env override + URL validation ────────────────
+
+    #[test]
+    fn test_upstream_url_inner_default_when_no_env() {
+        let url = upstream_url_inner(|_| None).expect("default URL must be valid");
+        assert_eq!(url, DEFAULT_UPSTREAM_URL);
+    }
+
+    #[test]
+    fn test_upstream_url_inner_uses_env_override() {
+        let url = upstream_url_inner(|k| {
+            (k == "RECIPE_RUNNER_UPSTREAM_URL")
+                .then(|| "https://example.com/repo.git".to_string())
+        })
+        .expect("https override must be accepted");
+        assert_eq!(url, "https://example.com/repo.git");
+    }
+
+    #[test]
+    fn test_upstream_url_inner_accepts_http() {
+        let url = upstream_url_inner(|_| Some("http://example.com/repo".to_string()))
+            .expect("http override must be accepted");
+        assert_eq!(url, "http://example.com/repo");
+    }
+
+    #[test]
+    fn test_upstream_url_inner_rejects_non_http_schemes() {
+        for bad in [
+            "file:///etc/passwd",
+            "ssh://git@example.com/repo",
+            "git://example.com/repo",
+            "ftp://example.com/repo",
+            "javascript:alert(1)",
+            "no-scheme",
+        ] {
+            let res = upstream_url_inner(|_| Some(bad.to_string()));
+            assert!(res.is_err(), "scheme must be rejected: {:?}", bad);
+            // Error message must NOT echo the raw value (security)
+            let msg = res.unwrap_err().to_string();
+            assert!(
+                !msg.contains(bad),
+                "error message must not echo raw env var value (got {:?})",
+                msg
+            );
+        }
+    }
+
+    #[test]
+    fn test_upstream_url_inner_rejects_embedded_userinfo() {
+        let res = upstream_url_inner(|_| {
+            Some("https://user:secret@example.com/repo".to_string())
+        });
+        assert!(res.is_err(), "URL with userinfo must be rejected");
+        let msg = res.unwrap_err().to_string();
+        assert!(
+            !msg.contains("secret") && !msg.contains("user:"),
+            "error must not leak credentials: {:?}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_upstream_url_inner_rejects_empty() {
+        let res = upstream_url_inner(|_| Some(String::new()));
+        assert!(res.is_err(), "empty URL must be rejected");
+    }
+
+    // ── #45: verify_global_installation must be removed ────────────────
+
+    /// Compile-time guarantee: verify_global_installation no longer exists.
+    /// If this module compiles after removal, the symbol is gone.
+    /// This test exists to document intent; the absence of the symbol is
+    /// the actual assertion (any caller would fail to compile).
+    #[test]
+    fn test_verify_global_installation_removed() {
+        // Intentionally empty — the surrounding cfg(test) module will fail
+        // to compile if any code references the deleted function.
     }
 
     #[test]

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -282,51 +282,6 @@ fn is_safe_recipe_name(name: &str) -> bool {
         && !name.contains("..")
 }
 
-/// Verify that global recipe directories exist and contain recipes.
-pub fn verify_global_installation() -> serde_json::Value {
-    let global_dirs = vec![
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".amplihack")
-            .join("amplifier-bundle")
-            .join("recipes"),
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".amplihack")
-            .join(".claude")
-            .join("recipes"),
-        PathBuf::from("amplifier-bundle").join("recipes"),
-    ];
-
-    let mut dirs_exist = Vec::new();
-    let mut recipe_counts = Vec::new();
-    let mut has_global = false;
-
-    for dir in &global_dirs {
-        let exists = dir.is_dir();
-        dirs_exist.push(exists);
-        if exists {
-            let count = collect_dir_entries(dir)
-                .iter()
-                .filter(|p| p.extension().is_some_and(|ext| ext == "yaml"))
-                .count();
-            recipe_counts.push(count);
-            if count > 0 {
-                has_global = true;
-            }
-        } else {
-            recipe_counts.push(0);
-        }
-    }
-
-    serde_json::json!({
-        "global_dirs_exist": dirs_exist,
-        "global_recipe_count": recipe_counts,
-        "has_global_recipes": has_global,
-        "global_paths_checked": global_dirs.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
-    })
-}
-
 /// Compare local recipe files against their content hashes.
 pub fn check_upstream_changes(local_dir: Option<&Path>) -> Vec<HashMap<String, String>> {
     let recipe_dir = match local_dir
@@ -857,6 +812,16 @@ steps:
             std::env::remove_var("AMPLIHACK_PACKAGE_RECIPE_DIR");
             std::env::remove_var("RECIPE_RUNNER_RECIPE_DIRS");
         }
+    }
+
+    // ── #45: verify_global_installation must be removed ────────────────
+
+    /// Compile-time guarantee: verify_global_installation no longer exists.
+    /// If this module compiles after removal, the symbol is gone.
+    #[test]
+    fn test_verify_global_installation_removed() {
+        // Intentionally empty — the surrounding cfg(test) module will fail
+        // to compile if any code references the deleted function.
     }
 
     // ── #42: find_recipe + discover_recipes must support .yml ──────────

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -83,9 +83,10 @@ pub struct RecipeInfo {
     pub sha256: String,
 }
 
-/// Find all recipe YAML files in the search directories.
+/// Find all recipe YAML files (`.yaml` and `.yml`) in the search directories.
 ///
 /// When the same recipe name appears in multiple directories, the last one wins.
+/// Within a single directory, `.yaml` takes precedence over `.yml` if both exist.
 pub fn discover_recipes(search_dirs: Option<&[PathBuf]>) -> HashMap<String, RecipeInfo> {
     let dirs = search_dirs
         .map(|d| d.to_vec())
@@ -103,9 +104,23 @@ pub fn discover_recipes(search_dirs: Option<&[PathBuf]>) -> HashMap<String, Reci
 
         let mut entries: Vec<PathBuf> = collect_dir_entries(search_dir)
             .into_iter()
-            .filter(|p| p.extension().is_some_and(|ext| ext == "yaml"))
+            .filter(|p| {
+                p.extension()
+                    .is_some_and(|ext| ext == "yaml" || ext == "yml")
+            })
             .collect();
-        entries.sort();
+        // Sort so .yaml is processed AFTER .yml for the same stem; combined
+        // with the last-wins HashMap insert, this gives .yaml precedence.
+        entries.sort_by(|a, b| {
+            let stem_a = a.file_stem().unwrap_or_default();
+            let stem_b = b.file_stem().unwrap_or_default();
+            stem_a.cmp(stem_b).then_with(|| {
+                let ext_a = a.extension().and_then(|s| s.to_str()).unwrap_or("");
+                let ext_b = b.extension().and_then(|s| s.to_str()).unwrap_or("");
+                // "yml" < "yaml" lexicographically, so reverse to put yaml last
+                ext_b.cmp(ext_a)
+            })
+        });
 
         for yaml_path in entries {
             if let Some(info) = load_recipe_info(&yaml_path) {
@@ -228,18 +243,43 @@ pub fn cached_discover_recipes(dirs: &[PathBuf]) -> HashMap<String, RecipeInfo> 
 }
 
 /// Find a recipe by name and return its file path.
+///
+/// Searches each directory in order, looking for `<name>.yaml` first then
+/// `<name>.yml` (yaml takes precedence when both exist in the same dir).
+///
+/// Returns `None` if `name` contains path-traversal segments (`/`, `\`, `..`)
+/// or starts with `.`, to prevent escaping the search directories.
 pub fn find_recipe(name: &str, search_dirs: Option<&[PathBuf]>) -> Option<PathBuf> {
+    if !is_safe_recipe_name(name) {
+        warn!("find_recipe: rejecting unsafe recipe name");
+        return None;
+    }
     let dirs = search_dirs
         .map(|d| d.to_vec())
         .unwrap_or_else(default_search_dirs);
-    let filename = format!("{}.yaml", name);
     for search_dir in &dirs {
-        let candidate = search_dir.join(&filename);
-        if candidate.is_file() {
-            return Some(candidate);
+        for ext in ["yaml", "yml"] {
+            let candidate = search_dir.join(format!("{}.{}", name, ext));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
         }
     }
     None
+}
+
+/// Reject recipe names that could escape the search directory or refer to
+/// hidden files. Names must be a single path component with no separator
+/// or parent-directory segments and must not start with `.`.
+fn is_safe_recipe_name(name: &str) -> bool {
+    if name.is_empty() || name.starts_with('.') {
+        return false;
+    }
+    !name
+        .chars()
+        .any(|c| c == '/' || c == '\\' || c == '\0')
+        && !name.split(['/', '\\']).any(|seg| seg == "..")
+        && !name.contains("..")
 }
 
 /// Verify that global recipe directories exist and contain recipes.
@@ -816,6 +856,77 @@ steps:
         unsafe {
             std::env::remove_var("AMPLIHACK_PACKAGE_RECIPE_DIR");
             std::env::remove_var("RECIPE_RUNNER_RECIPE_DIRS");
+        }
+    }
+
+    // ── #42: find_recipe + discover_recipes must support .yml ──────────
+
+    #[test]
+    fn test_find_recipe_finds_yml_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("yml-recipe.yml"),
+            "name: yml-recipe\nsteps:\n  - id: s1\n    command: echo",
+        )
+        .unwrap();
+        let found = find_recipe("yml-recipe", Some(&[tmp.path().to_path_buf()]));
+        assert!(
+            found.is_some(),
+            "find_recipe must locate .yml files, not only .yaml"
+        );
+        assert!(found.unwrap().extension().unwrap() == "yml");
+    }
+
+    #[test]
+    fn test_find_recipe_yaml_takes_precedence_over_yml() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("dup.yaml"),
+            "name: dup\nsteps:\n  - id: s1\n    command: echo yaml",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("dup.yml"),
+            "name: dup\nsteps:\n  - id: s1\n    command: echo yml",
+        )
+        .unwrap();
+        let found = find_recipe("dup", Some(&[tmp.path().to_path_buf()])).unwrap();
+        assert_eq!(
+            found.extension().unwrap(),
+            "yaml",
+            ".yaml must win over .yml when both exist"
+        );
+    }
+
+    #[test]
+    fn test_discover_recipes_includes_yml_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("a.yaml"),
+            "name: a\nsteps:\n  - id: s1\n    command: echo",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("b.yml"),
+            "name: b\nsteps:\n  - id: s1\n    command: echo",
+        )
+        .unwrap();
+        let recipes = discover_recipes(Some(&[tmp.path().to_path_buf()]));
+        assert!(recipes.contains_key("a"), ".yaml must be discovered");
+        assert!(recipes.contains_key("b"), ".yml must be discovered");
+    }
+
+    #[test]
+    fn test_find_recipe_rejects_path_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Even if a malicious file exists outside the search dir, name with
+        // traversal segments must not resolve to it.
+        for bad in ["../etc/passwd", "../../foo", "a/b", "a\\b", ".hidden"] {
+            assert!(
+                find_recipe(bad, Some(&[tmp.path().to_path_buf()])).is_none(),
+                "find_recipe must reject suspicious name: {:?}",
+                bad
+            );
         }
     }
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -275,9 +275,10 @@ fn is_safe_recipe_name(name: &str) -> bool {
     if name.is_empty() || name.starts_with('.') {
         return false;
     }
-    !name.chars().any(|c| c == '/' || c == '\\' || c == '\0')
-        && !name.split(['/', '\\']).any(|seg| seg == "..")
-        && !name.contains("..")
+    // Reject any path separator/NUL byte; a `..` segment cannot exist without
+    // one, so the broader `contains("..")` also catches any non-separator
+    // attempts to embed parent-dir markers.
+    !name.chars().any(|c| matches!(c, '/' | '\\' | '\0')) && !name.contains("..")
 }
 
 /// Compare local recipe files against their content hashes.
@@ -946,7 +947,15 @@ steps:
         let tmp = tempfile::tempdir().unwrap();
         // Even if a malicious file exists outside the search dir, name with
         // traversal segments must not resolve to it.
-        for bad in ["../etc/passwd", "../../foo", "a/b", "a\\b", ".hidden"] {
+        for bad in [
+            "../etc/passwd",
+            "../../foo",
+            "a/b",
+            "a\\b",
+            ".hidden",
+            "foo..bar",
+            "",
+        ] {
             assert!(
                 find_recipe(bad, Some(&[tmp.path().to_path_buf()])).is_none(),
                 "find_recipe must reject suspicious name: {:?}",

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -275,9 +275,7 @@ fn is_safe_recipe_name(name: &str) -> bool {
     if name.is_empty() || name.starts_with('.') {
         return false;
     }
-    !name
-        .chars()
-        .any(|c| c == '/' || c == '\\' || c == '\0')
+    !name.chars().any(|c| c == '/' || c == '\\' || c == '\0')
         && !name.split(['/', '\\']).any(|seg| seg == "..")
         && !name.contains("..")
 }
@@ -968,8 +966,7 @@ steps:
     #[test]
     fn test_upstream_url_inner_uses_env_override() {
         let url = upstream_url_inner(|k| {
-            (k == "RECIPE_RUNNER_UPSTREAM_URL")
-                .then(|| "https://example.com/repo.git".to_string())
+            (k == "RECIPE_RUNNER_UPSTREAM_URL").then(|| "https://example.com/repo.git".to_string())
         })
         .expect("https override must be accepted");
         assert_eq!(url, "https://example.com/repo.git");
@@ -1006,9 +1003,7 @@ steps:
 
     #[test]
     fn test_upstream_url_inner_rejects_embedded_userinfo() {
-        let res = upstream_url_inner(|_| {
-            Some("https://user:secret@example.com/repo".to_string())
-        });
+        let res = upstream_url_inner(|_| Some("https://user:secret@example.com/repo".to_string()));
         assert!(res.is_err(), "URL with userinfo must be rejected");
         let msg = res.unwrap_err().to_string();
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,10 +118,11 @@ fn parse_context_value(raw: &str) -> Value {
     {
         return v;
     }
-    // Try boolean
+    // Try boolean (capitalized only; lowercase is handled above by serde_json,
+    // which parses "true"/"false" as Value::Bool).
     match raw {
-        "true" | "True" => return Value::Bool(true),
-        "false" | "False" => return Value::Bool(false),
+        "True" => return Value::Bool(true),
+        "False" => return Value::Bool(false),
         _ => {}
     }
     // Try integer
@@ -411,6 +412,22 @@ mod tests {
     use serde_json::json;
 
     // -- RR-M7: parse_context_value unit tests --
+
+    #[test]
+    fn test_parse_context_value_bool_both_paths_after_dead_arm_removal() {
+        // After removing the unreachable `"true"`/`"false"` arms, both
+        // lowercase (handled by serde_json) and capitalized (handled by
+        // the explicit match arm) must still produce Value::Bool.
+        // Lowercase: takes the serde_json path (returns Value::Bool, !is_string()).
+        assert_eq!(parse_context_value("true"), json!(true));
+        assert_eq!(parse_context_value("false"), json!(false));
+        // Capitalized: not valid JSON, falls through to the match arm.
+        assert_eq!(parse_context_value("True"), json!(true));
+        assert_eq!(parse_context_value("False"), json!(false));
+        // Other capitalizations are NOT booleans (intentional, preserved).
+        assert_eq!(parse_context_value("TRUE"), json!("TRUE"));
+        assert_eq!(parse_context_value("tRuE"), json!("tRuE"));
+    }
 
     #[test]
     fn test_parse_context_value_string() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -246,18 +246,22 @@ impl Default for RecipeParser {
     }
 }
 
-/// Resolve single-level recipe inheritance via the `extends` field.
+/// Resolve recipe inheritance via the `extends` field, recursively.
 ///
 /// If `recipe.extends` is `Some`, finds and parses the parent recipe, then
-/// merges the parent into the child:
-/// - Child context values override parent context values
-/// - Child steps are appended after parent steps
-/// - Child name, version, description override parent
-/// - Parent tags are merged with child tags (union)
-/// - Recursion config: child overrides if set (non-default)
-/// - Hooks: child overrides if set
+/// recursively resolves the parent's own `extends` chain *before* merging
+/// the parent into the child. The merge semantics are:
 ///
-/// Only single-level inheritance is supported (parent's `extends` is ignored).
+/// - Child context values override parent context values
+/// - Child steps are appended after parent steps (ancestor-first ordering)
+/// - Child name, version, description override parent
+/// - Parent tags are merged with child tags (union, sorted)
+/// - Recursion config: child overrides if non-default, otherwise inherited
+/// - Hooks: each hook field is inherited individually if unset on the child
+///
+/// Cycles in the `extends` chain are detected via a path-based visited set
+/// and reported as an error of the form
+/// `"Circular extends detected: '<name>' was already visited in the extends chain"`.
 pub fn resolve_extends(recipe: &mut Recipe, search_dirs: &[PathBuf]) -> Result<(), ParseError> {
     info!(
         "resolve_extends: resolving extends for recipe '{}'",
@@ -563,6 +567,100 @@ steps:
         let mut recipe = parser.parse(yaml).unwrap();
         let err = resolve_extends(&mut recipe, &[]).unwrap_err();
         assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_resolve_extends_recursive_three_level_chain() {
+        // grandparent <- parent <- child : steps must be ordered
+        // grandparent's steps, then parent's, then child's.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("grand.yaml"),
+            r#"
+name: "grand"
+context:
+  layer: "grand"
+  grand_only: "g"
+steps:
+  - id: "grand-step"
+    command: "echo grand"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("mid.yaml"),
+            r#"
+name: "mid"
+extends: "grand"
+context:
+  layer: "mid"
+  mid_only: "m"
+steps:
+  - id: "mid-step"
+    command: "echo mid"
+"#,
+        )
+        .unwrap();
+
+        let child_yaml = r#"
+name: "leaf"
+extends: "mid"
+context:
+  layer: "leaf"
+steps:
+  - id: "leaf-step"
+    command: "echo leaf"
+"#;
+        let parser = RecipeParser::new();
+        let mut recipe = parser.parse(child_yaml).unwrap();
+        let dirs = vec![tmp.path().to_path_buf()];
+        resolve_extends(&mut recipe, &dirs).unwrap();
+
+        // All three levels' steps appear in dependency order
+        let ids: Vec<&str> = recipe.steps.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["grand-step", "mid-step", "leaf-step"]);
+        // Deepest child wins on overlapping context key
+        assert_eq!(
+            recipe.context.get("layer").and_then(|v| v.as_str()),
+            Some("leaf")
+        );
+        // Inherited keys from both ancestors are present
+        assert_eq!(
+            recipe.context.get("grand_only").and_then(|v| v.as_str()),
+            Some("g")
+        );
+        assert_eq!(
+            recipe.context.get("mid_only").and_then(|v| v.as_str()),
+            Some("m")
+        );
+        assert!(recipe.extends.is_none(), "extends must be consumed");
+    }
+
+    #[test]
+    fn test_resolve_extends_detects_cycle() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("a.yaml"),
+            "name: a\nextends: b\nsteps:\n  - id: a1\n    command: echo",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("b.yaml"),
+            "name: b\nextends: a\nsteps:\n  - id: b1\n    command: echo",
+        )
+        .unwrap();
+        let parser = RecipeParser::new();
+        let mut recipe = parser
+            .parse_file(&tmp.path().join("a.yaml"))
+            .unwrap();
+        let err = resolve_extends(&mut recipe, &[tmp.path().to_path_buf()])
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Circular extends") || msg.to_lowercase().contains("circular"),
+            "expected cycle error, got: {}",
+            msg
+        );
     }
 
     // ── Edge cases (test-5) ──────────────────────────────

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -650,11 +650,8 @@ steps:
         )
         .unwrap();
         let parser = RecipeParser::new();
-        let mut recipe = parser
-            .parse_file(&tmp.path().join("a.yaml"))
-            .unwrap();
-        let err = resolve_extends(&mut recipe, &[tmp.path().to_path_buf()])
-            .unwrap_err();
+        let mut recipe = parser.parse_file(&tmp.path().join("a.yaml")).unwrap();
+        let err = resolve_extends(&mut recipe, &[tmp.path().to_path_buf()]).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("Circular extends") || msg.to_lowercase().contains("circular"),

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -32,7 +32,7 @@ pub use listeners::{ExecutionListener, FileLogListener, NullListener, StderrList
 const MAX_PARALLEL_STEPS: usize = 50;
 
 /// Maximum size of step output stored in memory (10 MB).
-const MAX_STEP_OUTPUT_BYTES: usize = 10_000_000;
+pub const MAX_STEP_OUTPUT_BYTES: usize = 10_000_000;
 
 /// Executes recipes by delegating steps to an adapter.
 pub struct RecipeRunner<A: Adapter> {

--- a/tests/discovery_tests.rs
+++ b/tests/discovery_tests.rs
@@ -1,22 +1,5 @@
-use recipe_runner_rs::discovery::{cached_discover_recipes, verify_global_installation};
+use recipe_runner_rs::discovery::cached_discover_recipes;
 use std::path::PathBuf;
-
-#[test]
-fn verify_global_returns_expected_fields() {
-    let result = verify_global_installation();
-    assert!(result.is_object());
-    let obj = result.as_object().unwrap();
-    assert!(obj.contains_key("global_dirs_exist"));
-    assert!(obj.contains_key("global_recipe_count"));
-    assert!(obj.contains_key("has_global_recipes"));
-    assert!(obj.contains_key("global_paths_checked"));
-
-    // global_dirs_exist and global_recipe_count must be arrays
-    assert!(obj["global_dirs_exist"].is_array());
-    assert!(obj["global_recipe_count"].is_array());
-    assert!(obj["has_global_recipes"].is_boolean());
-    assert!(obj["global_paths_checked"].is_array());
-}
 
 #[test]
 fn cached_discover_returns_consistent_results() {


### PR DESCRIPTION
Cluster fix for six small code-quality bugs in `src/discovery.rs`, the recipe parser, the runner, and the CLI subprocess adapter. Each issue is addressed in its own commit for clean review.

## Issues fixed

- Closes #42 — `find_recipe`/`discover_recipes` now support both `.yaml` and `.yml`; `find_recipe` rejects path-traversal names.
- Closes #43 — Doc on `resolve_extends` now correctly describes recursive resolution and cycle detection.
- Closes #44 — Removed unreachable lowercase `"true"`/`"false"` arms in `parse_context_value`.
- Closes #45 — Deleted orphaned `verify_global_installation` function and its integration test.
- Closes #46 — Upstream sync URL is configurable via `RECIPE_RUNNER_UPSTREAM_URL` env var with scheme allowlist (http/https only) and userinfo rejection.
- Closes #47 — Agent output reads in `cli_subprocess` are now capped at `MAX_STEP_OUTPUT_BYTES + 1` bytes via a new `read_capped` helper, preventing unbounded memory growth from runaway agents.

## Tests added

| Issue | File | Tests |
|-------|------|-------|
| #42 | `src/discovery.rs` | `test_find_recipe_finds_yml_extension`, `test_find_recipe_yaml_takes_precedence_over_yml`, `test_discover_recipes_includes_yml_files`, `test_find_recipe_rejects_path_traversal` |
| #43 | `src/parser.rs` | `test_resolve_extends_recursive_three_level_chain`, `test_resolve_extends_detects_cycle` |
| #44 | `src/main.rs` | `test_parse_context_value_bool_both_paths_after_dead_arm_removal` |
| #45 | `src/discovery.rs` | `test_verify_global_installation_removed` (compile-time guard) |
| #46 | `src/discovery.rs` | 6 tests covering default, env override, scheme allowlist, userinfo rejection, empty rejection |
| #47 | `src/adapters/cli_subprocess.rs` | 4 tests covering small reads, MAX+1 cap, missing file, real `MAX_STEP_OUTPUT_BYTES` enforcement |

## Validation

- `cargo test` — all 511 tests pass
- `cargo clippy --all-targets -- -D warnings` — clean

## Security notes

- `#42`: Recipe name validation prevents directory traversal via `..`, `/`, `\`, leading `.`.
- `#46`: Scheme allowlist blocks `file://`, `ssh://`, `git://`, etc.; embedded credentials are rejected; error messages do not echo raw env values.
- `#47`: Bounded read defends against agent OOM attacks.

## Out of scope

- No CI / config changes.
- No refactors beyond the six fixes.
- `O_NOFOLLOW` symlink protection on agent output is a pre-existing concern documented as a follow-up.
