### PR TITLE
fix(adapters): guarantee HOME and PATH in child env (#101)

### DIFF
--- a/src/adapters/cli_subprocess.rs
+++ b/src/adapters/cli_subprocess.rs
@@ -89,6 +89,19 @@ impl CLISubprocessAdapter {
         let mut child_env: HashMap<String, String> =
             env::vars().filter(|(k, _)| k != "CLAUDECODE").collect();
 
+        // Defense-in-depth: ensure HOME and PATH are always present and non-empty,
+        // even when the parent shell has them unset. Mirrors amplihack-rs fork
+        // (fix #277) — empty HOME/PATH can break non-interactive child steps.
+        if child_env.get("HOME").is_none_or(|v| v.is_empty()) {
+            child_env.insert("HOME".to_string(), "/root".to_string());
+        }
+        if child_env.get("PATH").is_none_or(|v| v.is_empty()) {
+            child_env.insert(
+                "PATH".to_string(),
+                "/usr/local/bin:/usr/bin:/bin".to_string(),
+            );
+        }
+
         let current_depth: u32 = env::var("AMPLIHACK_SESSION_DEPTH")
             .ok()
             .and_then(|s| s.parse().ok())
@@ -852,6 +865,17 @@ mod tests {
         assert!(env.contains_key("AMPLIHACK_MAX_SESSIONS"));
         // CLAUDECODE is never passed to children
         assert!(!env.contains_key("CLAUDECODE"));
+    }
+
+    #[test]
+    fn test_build_child_env_guarantees_home_and_path() {
+        // Fix #277 parity with amplihack-rs fork: HOME and PATH must always be
+        // present and non-empty, even when unset in parent.
+        let env = CLISubprocessAdapter::build_child_env();
+        assert!(env.contains_key("HOME"));
+        assert!(env.contains_key("PATH"));
+        assert!(!env.get("HOME").unwrap().is_empty());
+        assert!(!env.get("PATH").unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #101.

## What

Adds defense-in-depth fallbacks for HOME and PATH in `CLISubprocessAdapter::build_child_env`:
- HOME → `/root` if unset or empty
- PATH → `/usr/local/bin:/usr/bin:/bin` if unset or empty

## Why

Ports the `fix #277` pattern from amplihack-rs `crates/amplihack-recipe/src/executor.rs`. Canonical already inherits env via `env::vars()` so normal shells are unaffected, but when the runner is launched from a sandboxed / minimal environment with empty HOME/PATH, child agent and bash steps can fail obscurely. This makes that case robust.

## What else was in #101

- **BASH_INLINE_LIMIT tempfile spill** — already implemented (cli_subprocess.rs:596)
- **Tempfile held until process exit** — already implemented (cli_subprocess.rs:651 `drop(script_file);`)

So this PR is the complete port; #101 can close on merge.

## Test plan

Added `test_build_child_env_guarantees_home_and_path` asserting both keys are present and non-empty. Full lib tests pass (`TMPDIR=/tmp cargo test --lib`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>