### PR TITLE
audit(test): property-based tests for parser and template engine

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1179,4 +1179,208 @@ mod tests {
         // The heredoc structure is preserved
         assert!(rendered.starts_with("cat <<'EOF'\n"));
     }
+
+    // ── Property-based tests (PR4: audit/proptest-parser-template) ──────
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Strategy: generate context data with string values
+        fn context_data() -> impl Strategy<Value = HashMap<String, Value>> {
+            proptest::collection::hash_map(
+                "[a-zA-Z][a-zA-Z0-9_]{0,10}",
+                "[a-zA-Z0-9 .,!?()]{0,50}".prop_map(|s| json!(s)),
+                0..=5,
+            )
+        }
+
+        // CT-1: render() never panics on arbitrary template strings
+        proptest! {
+            #[test]
+            fn render_no_panic(
+                template in "\\PC{0,200}",
+                data in context_data(),
+            ) {
+                let c = RecipeContext::new(data);
+                let _ = c.render(&template);
+            }
+        }
+
+        // CT-2: render_shell() never panics on arbitrary template strings
+        proptest! {
+            #[test]
+            fn render_shell_no_panic(
+                template in "\\PC{0,300}",
+                data in context_data(),
+            ) {
+                let c = RecipeContext::new(data);
+                let _ = c.render_shell(&template);
+            }
+        }
+
+        // CT-3: render() produces no {{var}} placeholders when all vars are defined
+        proptest! {
+            #[test]
+            fn render_resolves_all_defined_vars(
+                data in context_data(),
+            ) {
+                let c = RecipeContext::new(data.clone());
+                // Build template using only keys that exist in context
+                let template: String = data.keys()
+                    .take(3)
+                    .map(|k| format!("{{{{{}}}}}", k))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                if !template.is_empty() {
+                    let rendered = c.render(&template);
+                    // No unresolved {{...}} should remain for defined variables
+                    for key in data.keys().take(3) {
+                        let placeholder = format!("{{{{{}}}}}", key);
+                        prop_assert!(
+                            !rendered.contains(&placeholder),
+                            "Rendered output still contains placeholder {} in: {}",
+                            placeholder, rendered
+                        );
+                    }
+                }
+            }
+        }
+
+        // CT-4: shell_env_vars() produces valid env var names
+        proptest! {
+            #[test]
+            fn shell_env_var_names_are_valid(
+                data in context_data(),
+            ) {
+                let c = RecipeContext::new(data);
+                let env = c.shell_env_vars();
+                for key in env.keys() {
+                    if key.starts_with("RECIPE_VAR_") {
+                        for ch in key.chars() {
+                            prop_assert!(
+                                ch.is_ascii_alphanumeric() || ch == '_',
+                                "Invalid char '{}' in env var name: {}",
+                                ch, key
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // CT-5: render_shell outside heredocs wraps vars in double-quoted env refs
+        proptest! {
+            #[test]
+            fn render_shell_outside_heredoc_uses_quoted_env_refs(
+                var_name in "[a-zA-Z][a-zA-Z0-9_]{0,10}",
+                value in "[a-zA-Z0-9]{1,20}",
+            ) {
+                let data = vec![(var_name.as_str(), json!(value))];
+                let c = ctx(data);
+                let template = format!("echo {{{{{}}}}}", var_name);
+                let rendered = c.render_shell(&template);
+                let env_key = format!("RECIPE_VAR_{}", var_name);
+                let expected = format!("echo \"${}\"", env_key);
+                prop_assert_eq!(rendered, expected,
+                    "Outside heredoc: {{{}}} should become \"${}\"", var_name, env_key);
+            }
+        }
+
+        // CT-6: render_shell inside unquoted heredoc uses unquoted env refs
+        proptest! {
+            #[test]
+            fn render_shell_heredoc_body_uses_unquoted_refs(
+                var_name in "[a-zA-Z][a-zA-Z0-9_]{0,10}",
+                value in "[a-zA-Z0-9]{1,20}",
+            ) {
+                let data = vec![(var_name.as_str(), json!(value))];
+                let c = ctx(data);
+                let template = format!("cat <<EOF\n{{{{{}}}}}\nEOF", var_name);
+                let rendered = c.render_shell(&template);
+                let env_key = format!("RECIPE_VAR_{}", var_name);
+                let lines: Vec<&str> = rendered.split('\n').collect();
+                prop_assert_eq!(
+                    lines[1],
+                    &format!("${}", env_key),
+                    "Heredoc body: {{{}}} should become ${} (no quotes)",
+                    var_name, env_key,
+                );
+            }
+        }
+
+        // CT-7: render_shell inside quoted heredoc inlines actual values
+        proptest! {
+            #[test]
+            fn render_shell_quoted_heredoc_inlines_values(
+                var_name in "[a-zA-Z][a-zA-Z0-9_]{0,10}",
+                value in "[a-zA-Z0-9 ]{1,20}",
+            ) {
+                let data = vec![(var_name.as_str(), json!(value.clone()))];
+                let c = ctx(data);
+                let template = format!("cat <<'EOF'\n{{{{{}}}}}\nEOF", var_name);
+                let rendered = c.render_shell(&template);
+                let lines: Vec<&str> = rendered.split('\n').collect();
+                prop_assert_eq!(
+                    lines[1],
+                    &value,
+                    "Quoted heredoc body: {{{}}} should be inlined as '{}'",
+                    var_name, value,
+                );
+                prop_assert!(
+                    !rendered.contains("$RECIPE_VAR"),
+                    "Quoted heredoc must not contain $RECIPE_VAR refs",
+                );
+            }
+        }
+
+        // CT-8: legacy uppercase aliases are never produced for POSIX-reserved names
+        proptest! {
+            #[test]
+            fn no_alias_for_reserved_names(
+                reserved in prop_oneof![
+                    Just("path".to_string()),
+                    Just("home".to_string()),
+                    Just("user".to_string()),
+                    Just("shell".to_string()),
+                    Just("tmpdir".to_string()),
+                    Just("lang".to_string()),
+                    Just("term".to_string()),
+                ],
+            ) {
+                let c = ctx(vec![(Box::leak(reserved.clone().into_boxed_str()), json!("x"))]);
+                let env = c.shell_env_vars();
+                let upper = reserved.to_ascii_uppercase();
+                prop_assert!(
+                    !env.contains_key(&upper),
+                    "Must not produce alias {} for reserved name {}",
+                    upper, reserved,
+                );
+            }
+        }
+
+        // CT-9: dot-notation get() is consistent with nested JSON access
+        proptest! {
+            #[test]
+            fn dot_notation_consistent_with_nested_json(
+                key in "[a-zA-Z][a-zA-Z0-9]{0,5}",
+                subkey in "[a-zA-Z][a-zA-Z0-9]{0,5}",
+                value in "[a-zA-Z0-9]{1,10}",
+            ) {
+                let nested = json!({subkey.clone(): value.clone()});
+                let c = ctx(vec![(Box::leak(key.clone().into_boxed_str()), nested)]);
+                let dot_path = format!("{}.{}", key, subkey);
+                let result = c.get(&dot_path);
+                prop_assert!(
+                    result.is_some(),
+                    "get('{}') should find nested value", dot_path,
+                );
+                prop_assert_eq!(
+                    result.unwrap(),
+                    &json!(value),
+                    "get('{}') should return '{}'", dot_path, value,
+                );
+            }
+        }
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -784,7 +784,7 @@ steps:
         /// Strategy: generate syntactically valid minimal YAML recipes.
         fn valid_recipe_yaml() -> impl Strategy<Value = String> {
             (
-                "[a-zA-Z][a-zA-Z0-9_-]{0,30}",  // recipe name
+                "[a-zA-Z][a-zA-Z0-9_-]{0,30}", // recipe name
                 proptest::collection::vec(
                     "[a-zA-Z][a-zA-Z0-9_-]{0,20}", // step IDs
                     1..=5,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -774,4 +774,120 @@ steps:
         assert!(result.is_ok());
         assert_eq!(result.unwrap().name, "test-recipe_v2.1 (beta)");
     }
+
+    // ── Property-based tests (PR4: audit/proptest-parser-template) ──────
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Strategy: generate syntactically valid minimal YAML recipes.
+        fn valid_recipe_yaml() -> impl Strategy<Value = String> {
+            (
+                "[a-zA-Z][a-zA-Z0-9_-]{0,30}",  // recipe name
+                proptest::collection::vec(
+                    "[a-zA-Z][a-zA-Z0-9_-]{0,20}", // step IDs
+                    1..=5,
+                ),
+            )
+                .prop_map(|(name, step_ids)| {
+                    let mut yaml = format!("name: \"{}\"\nsteps:\n", name);
+                    // Deduplicate step IDs
+                    let mut seen = std::collections::HashSet::new();
+                    for (i, id) in step_ids.iter().enumerate() {
+                        let unique_id = if seen.insert(id.clone()) {
+                            id.clone()
+                        } else {
+                            format!("{}-dup{}", id, i)
+                        };
+                        yaml.push_str(&format!(
+                            "  - id: \"{}\"\n    command: \"echo step {}\"\n",
+                            unique_id, i
+                        ));
+                    }
+                    yaml
+                })
+        }
+
+        // P4-1: Parser never panics on arbitrary byte strings
+        proptest! {
+            #[test]
+            fn parser_no_panic_on_arbitrary_input(s in "\\PC{0,500}") {
+                let parser = RecipeParser::new();
+                let _ = parser.parse(&s);
+            }
+        }
+
+        // P4-2: Valid YAML recipes always parse successfully
+        proptest! {
+            #[test]
+            fn valid_recipes_always_parse(yaml in valid_recipe_yaml()) {
+                let parser = RecipeParser::new();
+                let result = parser.parse(&yaml);
+                prop_assert!(result.is_ok(), "Failed to parse valid YAML:\n{}\nError: {:?}", yaml, result.err());
+            }
+        }
+
+        // P4-3: Size limit is enforced — any input > MAX_YAML_SIZE_BYTES is rejected
+        proptest! {
+            #[test]
+            fn oversized_yaml_rejected(extra in 1..1000usize) {
+                let parser = RecipeParser::new();
+                let base = "name: test\nsteps:\n  - id: s1\n    command: echo ";
+                let padding = "x".repeat(MAX_YAML_SIZE_BYTES - base.len() + extra);
+                let yaml = format!("{}{}", base, padding);
+                prop_assert!(yaml.len() > MAX_YAML_SIZE_BYTES);
+                let result = parser.parse(&yaml);
+                prop_assert!(result.is_err(), "Oversized YAML should be rejected");
+                let err_msg = result.unwrap_err().to_string();
+                prop_assert!(err_msg.contains("too large"), "Error should mention size limit: {}", err_msg);
+            }
+        }
+
+        // P4-4: Parse then validate roundtrip — parsed recipes always validate without panic
+        proptest! {
+            #[test]
+            fn parse_then_validate_no_panic(yaml in valid_recipe_yaml()) {
+                let parser = RecipeParser::new();
+                if let Ok(recipe) = parser.parse(&yaml) {
+                    let _warnings = parser.validate(&recipe);
+                    // Also test validate_with_yaml path
+                    let _warnings_with_yaml = parser.validate_with_yaml(&recipe, Some(&yaml));
+                }
+            }
+        }
+
+        // P4-5: Duplicate step IDs are always detected
+        proptest! {
+            #[test]
+            fn duplicate_ids_detected(
+                name in "[a-zA-Z][a-zA-Z0-9]{0,10}",
+                dup_id in "[a-zA-Z][a-zA-Z0-9]{0,10}",
+            ) {
+                let yaml = format!(
+                    "name: \"{}\"\nsteps:\n  - id: \"{}\"\n    command: echo a\n  - id: \"{}\"\n    command: echo b\n",
+                    name, dup_id, dup_id
+                );
+                let parser = RecipeParser::new();
+                let result = parser.parse(&yaml);
+                prop_assert!(result.is_err(), "Duplicate IDs should be rejected");
+                let msg = result.unwrap_err().to_string();
+                prop_assert!(msg.contains("Duplicate"), "Error should mention duplicate: {}", msg);
+            }
+        }
+
+        // P4-6: Empty names are always rejected
+        proptest! {
+            #[test]
+            fn empty_name_rejected(step_cmd in "[a-zA-Z0-9 ]{1,30}") {
+                let yaml = format!(
+                    "name: \"\"\nsteps:\n  - id: \"s1\"\n    command: \"{}\"\n",
+                    step_cmd
+                );
+                let parser = RecipeParser::new();
+                let result = parser.parse(&yaml);
+                prop_assert!(result.is_err(), "Empty name should be rejected");
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Audit Context

Part of the comprehensive amplihack-recipe-runner audit (PR4 — MEDIUM priority).
Addresses **AC-8: proptest where applicable** for the YAML parser and template engine.

## Problem

The parser and template engine have good unit test coverage but lack fuzz/property
testing to catch edge cases in:
- YAML parsing of arbitrary/malformed input
- Template variable resolution completeness
- Heredoc-aware rendering correctness
- Size limit enforcement boundaries

## Fix

Added 15 property-based tests using `proptest`:

### Parser proptests (6 tests in `src/parser.rs`)
| ID | Property |
|----|----------|
| P4-1 | Parser never panics on arbitrary byte strings |
| P4-2 | Structurally valid YAML recipes always parse |
| P4-3 | Any input > MAX_YAML_SIZE_BYTES rejected with "too large" |
| P4-4 | Parse→validate roundtrip never panics |
| P4-5 | Duplicate step IDs always caught |
| P4-6 | Empty recipe names always rejected |

### Template engine proptests (9 tests in `src/context.rs`)
| ID | Property |
|----|----------|
| CT-1 | `render()` never panics on arbitrary templates |
| CT-2 | `render_shell()` never panics on arbitrary templates |
| CT-3 | All defined variables resolved (no leftover `{{...}}`) |
| CT-4 | `RECIPE_VAR_*` names contain only `[A-Z0-9_]` |
| CT-5 | Outside heredoc: `{{x}}` → `"$RECIPE_VAR_x"` |
| CT-6 | Inside heredoc: `{{x}}` → `$RECIPE_VAR_x` (no quotes) |
| CT-7 | Quoted heredoc: `{{x}}` → literal value |
| CT-8 | POSIX-reserved names never get uppercase aliases |
| CT-9 | Dot-notation `get()` consistent with nested JSON access |

**Test-only changes — no production code modified.**

## Test Plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `TMPDIR=/tmp cargo test` — all 95 tests pass (including 15 new proptests)
- [x] Each proptest runs 256 cases by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-authored-by: Copilot <copilot@github.com>