### PR TITLE
audit(test): property-based tests for state machines

### DIFF
--- a/src/progress_validator.rs
+++ b/src/progress_validator.rs
@@ -732,4 +732,229 @@ mod tests {
         assert!(workstream_progress_sidecar_path().is_none());
         assert!(workstream_state_file_path().is_none());
     }
+
+    // ── Property-based tests (PR5: audit/proptest-state-machines) ───────
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Strategy: generate arbitrary ProgressStatus values
+        fn arb_status() -> impl Strategy<Value = ProgressStatus> {
+            prop_oneof![
+                Just(ProgressStatus::Running),
+                Just(ProgressStatus::Completed),
+                Just(ProgressStatus::Failed),
+                Just(ProgressStatus::Skipped),
+                Just(ProgressStatus::Unknown),
+            ]
+        }
+
+        // PV-1: Terminal states have no valid outgoing transitions
+        proptest! {
+            #[test]
+            fn terminal_states_have_no_transitions(
+                status in prop_oneof![
+                    Just(ProgressStatus::Completed),
+                    Just(ProgressStatus::Failed),
+                    Just(ProgressStatus::Skipped),
+                ],
+            ) {
+                prop_assert!(
+                    status.valid_transitions().is_empty(),
+                    "{:?} is terminal but has non-empty transitions: {:?}",
+                    status, status.valid_transitions(),
+                );
+                prop_assert!(
+                    status.is_terminal(),
+                    "{:?} should report is_terminal() == true",
+                    status,
+                );
+            }
+        }
+
+        // PV-2: Non-terminal states have at least one valid transition
+        proptest! {
+            #[test]
+            fn non_terminal_states_have_transitions(
+                status in prop_oneof![
+                    Just(ProgressStatus::Running),
+                    Just(ProgressStatus::Unknown),
+                ],
+            ) {
+                prop_assert!(
+                    !status.valid_transitions().is_empty(),
+                    "{:?} is non-terminal but has no transitions",
+                    status,
+                );
+                prop_assert!(
+                    !status.is_terminal(),
+                    "{:?} should report is_terminal() == false",
+                    status,
+                );
+            }
+        }
+
+        // PV-3: validate_transition accepts self-transitions for all statuses
+        proptest! {
+            #[test]
+            fn self_transition_always_ok(status in arb_status()) {
+                prop_assert!(
+                    validate_transition(status, status).is_ok(),
+                    "{:?} → {:?} should be accepted (self-transition)",
+                    status, status,
+                );
+            }
+        }
+
+        // PV-4: validate_transition rejects transitions FROM terminal states to different states
+        proptest! {
+            #[test]
+            fn terminal_to_different_rejected(
+                from in prop_oneof![
+                    Just(ProgressStatus::Completed),
+                    Just(ProgressStatus::Failed),
+                    Just(ProgressStatus::Skipped),
+                ],
+                to in arb_status(),
+            ) {
+                if from != to {
+                    prop_assert!(
+                        validate_transition(from, to).is_err(),
+                        "Terminal {:?} → {:?} should be rejected",
+                        from, to,
+                    );
+                }
+            }
+        }
+
+        // PV-5: All transitions listed in valid_transitions() are accepted by validate_transition
+        proptest! {
+            #[test]
+            fn valid_transitions_are_accepted(from in arb_status()) {
+                for &to in from.valid_transitions() {
+                    prop_assert!(
+                        validate_transition(from, to).is_ok(),
+                        "{:?}.valid_transitions() includes {:?} but validate_transition rejects it",
+                        from, to,
+                    );
+                }
+            }
+        }
+
+        // PV-6: validate_filename never panics on arbitrary strings
+        proptest! {
+            #[test]
+            fn validate_filename_no_panic(s in "\\PC{0,200}") {
+                let _ = validate_filename(&s);
+            }
+        }
+
+        // PV-7: safe_progress_name always produces a string within MAX_SAFE_NAME_LEN
+        proptest! {
+            #[test]
+            fn safe_name_length_bounded(name in "\\PC{0,300}") {
+                let safe = safe_progress_name(&name);
+                prop_assert!(
+                    safe.len() <= MAX_SAFE_NAME_LEN,
+                    "safe_progress_name({:?}) produced {} chars (max {})",
+                    name, safe.len(), MAX_SAFE_NAME_LEN,
+                );
+            }
+        }
+
+        // PV-8: safe_progress_name only contains [a-zA-Z0-9_]
+        proptest! {
+            #[test]
+            fn safe_name_chars_valid(name in "\\PC{1,100}") {
+                let safe = safe_progress_name(&name);
+                for ch in safe.chars() {
+                    prop_assert!(
+                        ch.is_ascii_alphanumeric() || ch == '_',
+                        "safe_progress_name({:?}) produced invalid char '{}' in '{}'",
+                        name, ch, safe,
+                    );
+                }
+            }
+        }
+
+        // PV-9: progress_file_path roundtrips through validate_filename
+        proptest! {
+            #[test]
+            fn progress_path_roundtrips_through_filename_validation(
+                name in "[a-zA-Z][a-zA-Z0-9_]{0,20}",
+                pid in 1..100_000u32,
+            ) {
+                if let Ok(path) = progress_file_path(&name, pid) {
+                    let filename = path.file_name()
+                        .and_then(|f| f.to_str())
+                        .expect("path should have a filename");
+                    let result = validate_filename(filename);
+                    prop_assert!(
+                        result.is_ok(),
+                        "progress_file_path produced filename '{}' that validate_filename rejects: {:?}",
+                        filename, result.err(),
+                    );
+                    let (_, parsed_pid) = result.unwrap();
+                    prop_assert_eq!(
+                        parsed_pid, pid,
+                        "PID mismatch: generated with {} but parsed as {}",
+                        pid, parsed_pid,
+                    );
+                }
+            }
+        }
+
+        // PV-10: validate_fields rejects step names exceeding MAX_STEP_NAME_LEN
+        proptest! {
+            #[test]
+            fn oversized_step_name_rejected(extra in 1..500usize) {
+                let step_name = "x".repeat(MAX_STEP_NAME_LEN + extra);
+                let payload = ProgressPayload {
+                    status: ProgressStatus::Running,
+                    step_name,
+                    timestamp: now_ts(),
+                    recipe_name: None,
+                    pid: None,
+                    current_step: None,
+                    total_steps: None,
+                    elapsed_seconds: None,
+                };
+                let result = validate_fields(&payload);
+                prop_assert!(result.is_err(), "Step name with {} chars should be rejected", MAX_STEP_NAME_LEN + extra);
+                prop_assert!(
+                    matches!(result.unwrap_err(), ValidationError::StepNameTooLong(_)),
+                    "Should be StepNameTooLong error"
+                );
+            }
+        }
+
+        // PV-11: validate_age rejects timestamps far in the future
+        proptest! {
+            #[test]
+            fn future_timestamps_rejected(drift in 31.0..10000.0f64) {
+                let ts = now_ts() + drift;
+                let result = validate_age(ts);
+                prop_assert!(
+                    result.is_err(),
+                    "Timestamp {:.0}s in the future should be rejected",
+                    drift,
+                );
+            }
+        }
+
+        // PV-12: validate_age rejects stale timestamps
+        proptest! {
+            #[test]
+            fn stale_timestamps_rejected(age in 7201.0..100000.0f64) {
+                let ts = now_ts() - age;
+                let result = validate_age(ts);
+                prop_assert!(
+                    result.is_err(),
+                    "Timestamp {:.0}s old should be rejected",
+                    age,
+                );
+            }
+        }
+    }
 }

--- a/src/sub_recipe_recovery.rs
+++ b/src/sub_recipe_recovery.rs
@@ -300,4 +300,197 @@ mod tests {
         };
         assert!(r.should_attempt_recovery(&ctx));
     }
+
+    // ── Property-based tests (PR5: audit/proptest-state-machines) ───────
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        // SR-1: classify_failure never panics on arbitrary input
+        proptest! {
+            #[test]
+            fn classify_failure_no_panic(
+                error in "\\PC{0,500}",
+                exit_code in proptest::option::of(0..256i32),
+            ) {
+                let r = SubRecipeRecovery::new();
+                let _ = r.classify_failure(&error, exit_code);
+            }
+        }
+
+        // SR-2: classify_failure always returns a valid FailureClass variant
+        proptest! {
+            #[test]
+            fn classify_failure_returns_valid_class(
+                error in "\\PC{0,200}",
+                exit_code in proptest::option::of(0..256i32),
+            ) {
+                let r = SubRecipeRecovery::new();
+                let class = r.classify_failure(&error, exit_code);
+                // Exhaustive match ensures totality — compiler would catch missing variants
+                match class {
+                    FailureClass::Recoverable | FailureClass::Unrecoverable | FailureClass::Unknown => {}
+                }
+            }
+        }
+
+        // SR-3: classify_failure is case-insensitive for known patterns
+        proptest! {
+            #[test]
+            fn classify_case_insensitive(
+                pattern in prop_oneof![
+                    Just("permission denied"),
+                    Just("test failed"),
+                    Just("fatal:"),
+                    Just("syntax error"),
+                ],
+            ) {
+                let r = SubRecipeRecovery::new();
+                let lower = r.classify_failure(pattern, None);
+                let upper = r.classify_failure(&pattern.to_uppercase(), None);
+                prop_assert_eq!(
+                    lower, upper,
+                    "classify_failure should be case-insensitive: '{}' vs '{}'",
+                    pattern, pattern.to_uppercase(),
+                );
+            }
+        }
+
+        // SR-4: Unrecoverable failures are never retried via should_attempt_recovery()
+        proptest! {
+            #[test]
+            fn unrecoverable_never_retried(attempt in 0..10u32) {
+                let r = SubRecipeRecovery::new();
+                let ctx = FailureContext {
+                    recipe_name: "test".into(),
+                    step_id: "s1".into(),
+                    error_message: "error".into(),
+                    exit_code: None,
+                    failure_class: FailureClass::Unrecoverable,
+                    attempt,
+                };
+                prop_assert!(
+                    !r.should_attempt_recovery(&ctx),
+                    "Unrecoverable failures should never be retried (attempt {})",
+                    attempt,
+                );
+            }
+        }
+
+        // SR-5: should_attempt_recovery() respects max_attempts for non-Unrecoverable
+        proptest! {
+            #[test]
+            fn max_attempts_respected(
+                max in 1..10u32,
+                attempt in 0..20u32,
+                class in prop_oneof![
+                    Just(FailureClass::Recoverable),
+                    Just(FailureClass::Unknown),
+                ],
+            ) {
+                let r = SubRecipeRecovery::with_max_attempts(max);
+                let ctx = FailureContext {
+                    recipe_name: "test".into(),
+                    step_id: "s1".into(),
+                    error_message: "error".into(),
+                    exit_code: None,
+                    failure_class: class,
+                    attempt,
+                };
+                let should = r.should_attempt_recovery(&ctx);
+                if attempt >= max {
+                    prop_assert!(
+                        !should,
+                        "attempt {} >= max {} should not be retried",
+                        attempt, max,
+                    );
+                } else {
+                    prop_assert!(
+                        should,
+                        "attempt {} < max {} should be retried for {:?}",
+                        attempt, max, class,
+                    );
+                }
+            }
+        }
+
+        // SR-6: parse_recovery_response never panics on arbitrary input
+        proptest! {
+            #[test]
+            fn parse_response_no_panic(
+                response in "\\PC{0,500}",
+                attempt in 0..100u32,
+            ) {
+                let r = SubRecipeRecovery::new();
+                let _ = r.parse_recovery_response(&response, attempt);
+            }
+        }
+
+        // SR-7: parse_recovery_response marks "UNRECOVERABLE" as not recovered
+        proptest! {
+            #[test]
+            fn unrecoverable_keyword_detected(
+                prefix in "[a-zA-Z ]{0,50}",
+                suffix in "[a-zA-Z ]{0,50}",
+            ) {
+                let r = SubRecipeRecovery::new();
+                let response = format!("{}UNRECOVERABLE{}", prefix, suffix);
+                let result = r.parse_recovery_response(&response, 0);
+                prop_assert!(
+                    !result.recovered,
+                    "Response containing 'UNRECOVERABLE' should not be marked recovered: {}",
+                    response,
+                );
+                prop_assert_eq!(
+                    result.strategy,
+                    "agent_declared_unrecoverable",
+                    "Strategy should be 'agent_declared_unrecoverable'",
+                );
+            }
+        }
+
+        // SR-8: build_recovery_prompt includes all context fields
+        proptest! {
+            #[test]
+            fn recovery_prompt_contains_context(
+                recipe_name in "[a-zA-Z][a-zA-Z0-9_-]{0,20}",
+                step_id in "[a-zA-Z][a-zA-Z0-9_-]{0,20}",
+                error_msg in "[a-zA-Z0-9 .,!?]{1,50}",
+                attempt in 0..5u32,
+            ) {
+                let r = SubRecipeRecovery::new();
+                let ctx = FailureContext {
+                    recipe_name: recipe_name.clone(),
+                    step_id: step_id.clone(),
+                    error_message: error_msg.clone(),
+                    exit_code: None,
+                    failure_class: FailureClass::Recoverable,
+                    attempt,
+                };
+                let prompt = r.build_recovery_prompt(&ctx);
+                prop_assert!(prompt.contains(&recipe_name), "Prompt missing recipe_name");
+                prop_assert!(prompt.contains(&step_id), "Prompt missing step_id");
+                prop_assert!(prompt.contains(&error_msg), "Prompt missing error_message");
+            }
+        }
+
+        // SR-9: Exit codes 126, 127, 137 are always classified as Unrecoverable
+        proptest! {
+            #[test]
+            fn fatal_exit_codes_unrecoverable(
+                code in prop_oneof![Just(126), Just(127), Just(137)],
+                error in "[a-zA-Z0-9 ]{0,50}",
+            ) {
+                let r = SubRecipeRecovery::new();
+                let class = r.classify_failure(&error, Some(code));
+                prop_assert_eq!(
+                    class,
+                    FailureClass::Unrecoverable,
+                    "Exit code {} should always be Unrecoverable regardless of error text '{}'",
+                    code, error,
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Audit Context

Part of the comprehensive amplihack-recipe-runner audit (PR5 — MEDIUM priority).
Addresses **AC-8: proptest where applicable** for the progress validator and
sub-recipe recovery state machines.

## Problem

Both modules implement state machine logic (status transitions, failure
classification) with good unit tests but lack property-based verification of:
- State transition invariants (terminal states, self-transitions)
- Classification totality (all inputs produce valid outputs)
- Boundary conditions (name length, timestamp freshness)
- Roundtrip correctness (generate path → validate filename)

## Fix

Added 21 property-based tests using `proptest`:

### Progress validator proptests (12 tests in `src/progress_validator.rs`)
| ID | Property |
|----|----------|
| PV-1 | Terminal states have no outgoing transitions |
| PV-2 | Non-terminal states have ≥1 transition |
| PV-3 | Self-transitions always accepted |
| PV-4 | Terminal→different always rejected |
| PV-5 | All listed `valid_transitions()` pass `validate_transition` |
| PV-6 | `validate_filename` never panics on arbitrary input |
| PV-7 | `safe_progress_name` length ≤ MAX_SAFE_NAME_LEN |
| PV-8 | `safe_progress_name` chars always `[a-zA-Z0-9_]` |
| PV-9 | `progress_file_path` roundtrips through `validate_filename` |
| PV-10 | Oversized step names rejected |
| PV-11 | Future timestamps (>30s) rejected |
| PV-12 | Stale timestamps (>7200s) rejected |

### Sub-recipe recovery proptests (9 tests in `src/sub_recipe_recovery.rs`)
| ID | Property |
|----|----------|
| SR-1 | `classify_failure` never panics on arbitrary input |
| SR-2 | `classify_failure` always returns valid `FailureClass` (totality) |
| SR-3 | Classification is case-insensitive |
| SR-4 | Unrecoverable never retried via `should_attempt_recovery()` |
| SR-5 | `should_attempt_recovery()` respects `max_attempts` boundary |
| SR-6 | `parse_recovery_response` never panics on arbitrary input |
| SR-7 | "UNRECOVERABLE" keyword always detected |
| SR-8 | Recovery prompt includes `recipe_name`, `step_id`, `error_message` |
| SR-9 | Exit codes 126/127/137 always Unrecoverable |

**Test-only changes — no production code modified.**

## Test Plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `TMPDIR=/tmp cargo test` — all 95 tests pass (including 21 new proptests)
- [x] Each proptest runs 256 cases by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-authored-by: Copilot <copilot@github.com>