### PR TITLE
style: cargo fmt on main (unblock CI)

### DIFF
--- a/src/adapters/cli_subprocess.rs
+++ b/src/adapters/cli_subprocess.rs
@@ -468,12 +468,7 @@ impl CLISubprocessAdapter {
                                             if line.is_empty() {
                                                 continue;
                                             }
-                                            eprintln!(
-                                                "  [{}] [{}] {}",
-                                                utc_hms(),
-                                                label,
-                                                line
-                                            );
+                                            eprintln!("  [{}] [{}] {}", utc_hms(), label, line);
                                         }
                                     }
                                 }


### PR DESCRIPTION
Mechanical `cargo fmt` to fix CI regression introduced when #105 merged. The Format step in ci.yml fails on main, blocking all open PRs (#107, #108, #109).

Zero behavior change.

Once this merges, rebase #107/#108/#109 to pick up the fix.