### PR TITLE
fix(adapters): enforce agent step timeout instead of silently dropping it

### DIFF
--- a/src/adapters/cli_subprocess.rs
+++ b/src/adapters/cli_subprocess.rs
@@ -531,11 +531,7 @@ impl CLISubprocessAdapter {
                         let _ = child.wait();
                         stop.store(true, Ordering::SeqCst);
                         let _ = heartbeat.join();
-                        anyhow::bail!(
-                            "Agent step timed out after {}s (killed pid {})",
-                            secs,
-                            pid
-                        );
+                        anyhow::bail!("Agent step timed out after {}s (killed pid {})", secs, pid);
                     }
                     None => std::thread::sleep(Duration::from_millis(250)),
                 }

--- a/src/adapters/cli_subprocess.rs
+++ b/src/adapters/cli_subprocess.rs
@@ -312,16 +312,18 @@ impl CLISubprocessAdapter {
         Ok(cmd)
     }
 
-    /// Internal: spawn agent with optional system prompt.
+    /// Internal: spawn agent with optional system prompt and timeout.
     ///
-    /// Agent steps run without a timeout — they complete when the underlying
-    /// CLI process exits.
+    /// When `timeout` is `Some(secs)`, the agent process is killed after the
+    /// given number of seconds.  Without a timeout the step runs until the
+    /// underlying CLI process exits on its own.
     fn execute_agent_step_impl(
         &self,
         prompt: &str,
         system_prompt: Option<&str>,
         model: Option<&str>,
         working_dir: &str,
+        timeout: Option<u64>,
     ) -> Result<String, anyhow::Error> {
         log::debug!(
             "execute_agent_step_impl: prompt_len={}, has_system_prompt={}, model={:?}, working_dir={:?}",
@@ -511,7 +513,36 @@ impl CLISubprocessAdapter {
             }
         });
 
-        let status = child.wait()?;
+        // Enforce timeout: poll in a loop instead of blocking on wait().
+        let status = if let Some(secs) = timeout {
+            let deadline = Instant::now() + Duration::from_secs(secs);
+            loop {
+                match child.try_wait()? {
+                    Some(s) => break s,
+                    None if Instant::now() >= deadline => {
+                        log::warn!(
+                            "Agent step timed out after {}s — killing pid {}",
+                            secs,
+                            child.id()
+                        );
+                        let pid = child.id();
+                        child.kill().ok();
+                        // Reap the zombie so we don't leak processes.
+                        let _ = child.wait();
+                        stop.store(true, Ordering::SeqCst);
+                        let _ = heartbeat.join();
+                        anyhow::bail!(
+                            "Agent step timed out after {}s (killed pid {})",
+                            secs,
+                            pid
+                        );
+                    }
+                    None => std::thread::sleep(Duration::from_millis(250)),
+                }
+            }
+        } else {
+            child.wait()?
+        };
         stop.store(true, Ordering::SeqCst);
         if let Err(e) = heartbeat.join() {
             log::warn!("Heartbeat thread panicked: {:?}", e);
@@ -604,8 +635,7 @@ impl Adapter for CLISubprocessAdapter {
             timeout,
             working_dir
         );
-        let _ = timeout; // TODO: enforce timeout
-        self.execute_agent_step_impl(prompt, system_prompt, model, working_dir)
+        self.execute_agent_step_impl(prompt, system_prompt, model, working_dir, timeout)
     }
 
     fn execute_bash_step(

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1508,6 +1508,62 @@ steps:
         );
     }
 
+    /// Adapter that fails after the timeout value it receives on agent steps,
+    /// simulating a timeout error from the real adapter.
+    struct TimeoutFailAdapter;
+    impl Adapter for TimeoutFailAdapter {
+        fn execute_agent_step(
+            &self,
+            _prompt: &str,
+            _agent_name: Option<&str>,
+            _system_prompt: Option<&str>,
+            _mode: Option<&str>,
+            _working_dir: &str,
+            _model: Option<&str>,
+            timeout: Option<u64>,
+        ) -> Result<String, anyhow::Error> {
+            if let Some(secs) = timeout {
+                anyhow::bail!("Agent step timed out after {}s", secs);
+            }
+            Ok("ok".to_string())
+        }
+        fn execute_bash_step(
+            &self,
+            command: &str,
+            _working_dir: &str,
+            _timeout: Option<u64>,
+            _extra_env: &std::collections::HashMap<String, String>,
+        ) -> Result<String, anyhow::Error> {
+            Ok(format!("Bash output for: {}", command))
+        }
+        fn is_available(&self) -> bool { true }
+        fn name(&self) -> &str { "timeout-fail-mock" }
+    }
+
+    /// Verify that the timeout field from a recipe agent step propagates to
+    /// the adapter and that a timeout failure is reported correctly.
+    #[test]
+    fn test_agent_step_timeout_propagated_and_reported() {
+        let yaml = r#"
+name: "test-agent-timeout"
+steps:
+  - id: "timed-agent"
+    prompt: "do something"
+    timeout: 300
+"#;
+        let parser = RecipeParser::new();
+        let recipe = parser.parse(yaml).unwrap();
+        let runner = RecipeRunner::new(TimeoutFailAdapter);
+        let result = runner.execute(&recipe, None);
+        assert!(!result.success, "adapter timeout error should cause step failure");
+        assert_eq!(result.step_results[0].status, StepStatus::Failed);
+        assert!(
+            result.step_results[0].error.contains("timed out"),
+            "error should mention timeout: {}",
+            result.step_results[0].error
+        );
+    }
+
     /// C2-RD-10: timeout:0 edge case — verify step still executes and completes
     /// normally. A zero timeout is passed to the adapter as `Some(0)` and the
     /// adapter decides what to do with it (mock adapter ignores timeout).

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1536,8 +1536,12 @@ steps:
         ) -> Result<String, anyhow::Error> {
             Ok(format!("Bash output for: {}", command))
         }
-        fn is_available(&self) -> bool { true }
-        fn name(&self) -> &str { "timeout-fail-mock" }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn name(&self) -> &str {
+            "timeout-fail-mock"
+        }
     }
 
     /// Verify that the timeout field from a recipe agent step propagates to
@@ -1555,7 +1559,10 @@ steps:
         let recipe = parser.parse(yaml).unwrap();
         let runner = RecipeRunner::new(TimeoutFailAdapter);
         let result = runner.execute(&recipe, None);
-        assert!(!result.success, "adapter timeout error should cause step failure");
+        assert!(
+            !result.success,
+            "adapter timeout error should cause step failure"
+        );
         assert_eq!(result.step_results[0].status, StepStatus::Failed);
         assert!(
             result.step_results[0].error.contains("timed out"),


### PR DESCRIPTION
## Summary

**Audit finding**: The `execute_agent_step` method received a `timeout` parameter but silently discarded it with `let _ = timeout; // TODO: enforce timeout`. This meant agent steps could run indefinitely even when a recipe specified a timeout value — a philosophy violation (TODO in non-test code + silent parameter drop).

**Fix**:
- Replace the blocking `child.wait()` with a poll loop that checks `child.try_wait()` every 250ms
- When the deadline expires, the child process is killed and reaped, and an `anyhow::bail!` error is returned
- Thread the `timeout` parameter through to `execute_agent_step_impl`
- Remove the TODO comment and silent `let _ =` drop

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — all 96 tests pass (95 existing + 1 new)
- [x] New `test_agent_step_timeout_propagated_and_reported` test verifies timeout propagation and failure reporting via `TimeoutFailAdapter`

## Audit context

- **Category**: TODO/FIXME in non-test code + silent parameter drop
- **Severity**: Medium — agent steps without timeout enforcement could hang indefinitely
- **Philosophy violation**: Zero-BS implementation (no TODOs, no stubs)

Co-Authored-By: Copilot <noreply@github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)