### PR TITLE
audit(safety): replace silent error drops with tracing diagnostics

### DIFF
--- a/src/adapters/cli_subprocess.rs
+++ b/src/adapters/cli_subprocess.rs
@@ -401,7 +401,9 @@ impl CLISubprocessAdapter {
         // we can include the agent's actual error output in the bail message
         // (the temp_dir gets cleaned up before the error is reported).
         let stderr_persist_dir = std::path::PathBuf::from("/tmp/amplihack-agent-stderr");
-        std::fs::create_dir_all(&stderr_persist_dir).ok();
+        if let Err(e) = std::fs::create_dir_all(&stderr_persist_dir) {
+            log::warn!("Failed to create stderr persist dir {}: {}", stderr_persist_dir.display(), e);
+        }
         let stderr_file = stderr_persist_dir.join(format!(
             "agent-stderr-{}.log",
             std::time::SystemTime::now()
@@ -463,7 +465,9 @@ impl CLISubprocessAdapter {
                                     use std::io::{Seek, SeekFrom};
                                     if file.seek(SeekFrom::Start(last_size)).is_ok() {
                                         let mut buf = String::new();
-                                        let _ = file.read_to_string(&mut buf);
+                                        if let Err(e) = file.read_to_string(&mut buf) {
+                                            log::debug!("heartbeat: read_to_string failed: {}", e);
+                                        }
                                         for line in buf.lines() {
                                             if line.is_empty() {
                                                 continue;
@@ -574,7 +578,9 @@ impl CLISubprocessAdapter {
         }
 
         // On success, remove the persistent stderr file
-        std::fs::remove_file(&stderr_file).ok();
+        if let Err(e) = std::fs::remove_file(&stderr_file) {
+            log::debug!("Failed to clean up stderr file {}: {}", stderr_file.display(), e);
+        }
 
         Ok(stdout.trim().to_string())
     }
@@ -645,7 +651,8 @@ impl Adapter for CLISubprocessAdapter {
                 .with_context(|| "Failed to create tempfile for large bash step")?;
             tf.write_all(command.as_bytes())
                 .with_context(|| "Failed to write large bash step to tempfile")?;
-            tf.flush().ok();
+            tf.flush()
+                .with_context(|| "Failed to flush large bash step tempfile")?;
             Some(tf)
         } else {
             None

--- a/src/adapters/cli_subprocess.rs
+++ b/src/adapters/cli_subprocess.rs
@@ -402,7 +402,11 @@ impl CLISubprocessAdapter {
         // (the temp_dir gets cleaned up before the error is reported).
         let stderr_persist_dir = std::path::PathBuf::from("/tmp/amplihack-agent-stderr");
         if let Err(e) = std::fs::create_dir_all(&stderr_persist_dir) {
-            log::warn!("Failed to create stderr persist dir {}: {}", stderr_persist_dir.display(), e);
+            log::warn!(
+                "Failed to create stderr persist dir {}: {}",
+                stderr_persist_dir.display(),
+                e
+            );
         }
         let stderr_file = stderr_persist_dir.join(format!(
             "agent-stderr-{}.log",
@@ -579,7 +583,11 @@ impl CLISubprocessAdapter {
 
         // On success, remove the persistent stderr file
         if let Err(e) = std::fs::remove_file(&stderr_file) {
-            log::debug!("Failed to clean up stderr file {}: {}", stderr_file.display(), e);
+            log::debug!(
+                "Failed to clean up stderr file {}: {}",
+                stderr_file.display(),
+                e
+            );
         }
 
         Ok(stdout.trim().to_string())

--- a/src/progress_validator.rs
+++ b/src/progress_validator.rs
@@ -186,13 +186,17 @@ pub fn atomic_write_json(path: &Path, payload: &serde_json::Value) -> std::io::R
             drop(f);
             match std::fs::rename(&tmp_path, path) {
                 Ok(()) => return Ok(()),
-                Err(_) => {
-                    let _ = std::fs::remove_file(&tmp_path);
+                Err(rename_err) => {
+                    log::debug!("Atomic rename failed ({}), falling back to direct write", rename_err);
+                    if let Err(e) = std::fs::remove_file(&tmp_path) {
+                        log::debug!("Failed to clean up temp file {}: {}", tmp_path.display(), e);
+                    }
                     // Fall through to direct write.
                 }
             }
         }
-        Err(_) => {
+        Err(e) => {
+            log::debug!("Atomic write temp file creation failed ({}), falling back to direct write", e);
             // Fall through to direct write.
         }
     }

--- a/src/progress_validator.rs
+++ b/src/progress_validator.rs
@@ -187,7 +187,10 @@ pub fn atomic_write_json(path: &Path, payload: &serde_json::Value) -> std::io::R
             match std::fs::rename(&tmp_path, path) {
                 Ok(()) => return Ok(()),
                 Err(rename_err) => {
-                    log::debug!("Atomic rename failed ({}), falling back to direct write", rename_err);
+                    log::debug!(
+                        "Atomic rename failed ({}), falling back to direct write",
+                        rename_err
+                    );
                     if let Err(e) = std::fs::remove_file(&tmp_path) {
                         log::debug!("Failed to clean up temp file {}: {}", tmp_path.display(), e);
                     }
@@ -196,7 +199,10 @@ pub fn atomic_write_json(path: &Path, payload: &serde_json::Value) -> std::io::R
             }
         }
         Err(e) => {
-            log::debug!("Atomic write temp file creation failed ({}), falling back to direct write", e);
+            log::debug!(
+                "Atomic write temp file creation failed ({}), falling back to direct write",
+                e
+            );
             // Fall through to direct write.
         }
     }

--- a/src/runner/audit.rs
+++ b/src/runner/audit.rs
@@ -33,7 +33,9 @@ pub fn open_audit_log(audit_dir: &Path, recipe_name: &str) -> Option<std::fs::Fi
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
+                if let Err(e) = f.set_permissions(std::fs::Permissions::from_mode(0o600)) {
+                    warn!("Failed to set audit log permissions to 0600: {}", e);
+                }
             }
             Some(f)
         }

--- a/src/runner/listeners.rs
+++ b/src/runner/listeners.rs
@@ -107,14 +107,18 @@ impl FileLogListener {
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_secs_f64())
                     .unwrap_or(0.0);
-                let _ = writeln!(
+                if let Err(e) = writeln!(
                     f,
                     r#"{{"type":"recipe_start","recipe":"{}","ts":{:.3},"pid":{}}}"#,
                     recipe_name,
                     ts,
                     std::process::id()
-                );
-                let _ = f.flush();
+                ) {
+                    log::warn!("Failed to write recipe log header: {}", e);
+                }
+                if let Err(e) = f.flush() {
+                    log::warn!("Failed to flush recipe log header: {}", e);
+                }
                 eprintln!("[amplihack] recipe log: {}", path.display());
                 Some((
                     Self {
@@ -133,8 +137,12 @@ impl FileLogListener {
 
     fn write_event(&self, event: &str) {
         if let Ok(mut f) = self.file.lock() {
-            let _ = writeln!(f, "{}", event);
-            let _ = f.flush();
+            if let Err(e) = writeln!(f, "{}", event) {
+                log::warn!("Failed to write recipe log event: {}", e);
+            }
+            if let Err(e) = f.flush() {
+                log::warn!("Failed to flush recipe log: {}", e);
+            }
         }
     }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -489,8 +489,10 @@ impl<A: Adapter> RecipeRunner<A> {
             {
                 warn!("{} hook failed for step '{}': {}", hook_name, step_id, e);
             }
-            if let Some(path) = context_file {
-                let _ = std::fs::remove_file(&path);
+            if let Some(path) = context_file
+                && let Err(e) = std::fs::remove_file(&path)
+            {
+                log::debug!("Failed to clean up context file {}: {}", path.display(), e);
             }
         }
     }
@@ -1211,8 +1213,10 @@ impl<A: Adapter> RecipeRunner<A> {
             },
         };
         // Clean up temp context file
-        if let Some(path) = context_file {
-            let _ = std::fs::remove_file(&path);
+        if let Some(path) = context_file
+            && let Err(e) = std::fs::remove_file(&path)
+        {
+            log::debug!("Failed to clean up context file {}: {}", path.display(), e);
         }
         result
     }


### PR DESCRIPTION
## Summary

**Audit finding**: Multiple locations across the codebase silently swallow I/O errors using `let _ =`, `.ok()`, or `Err(_)` match arms. While most are cleanup operations where failure is non-fatal, silently dropping errors makes debugging impossible when they do matter.

**Critical fix**: `tf.flush().ok()` in the bash step tempfile path — if flush fails, the script written to the tempfile is incomplete, leading to silent wrong behavior. Promoted to `with_context` so it fails fast.

**Other fixes** (all non-behavioral — same fallthrough paths, now with logging):
- `cli_subprocess.rs`: log `create_dir_all`, `remove_file`, and heartbeat read failures
- `runner/mod.rs`: log context-file cleanup failures, collapse nested if-let per clippy
- `runner/audit.rs`: log `set_permissions` failure at warn level (security-relevant — audit log may be world-readable)
- `runner/listeners.rs`: log write/flush failures at warn level
- `progress_validator.rs`: log atomic-write fallback reasons at debug level

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — all 95 tests pass
- [x] No behavioral changes to existing code paths

## Audit context

- **Category**: Silently swallowed Result/Option values
- **Severity**: Low-Medium (most are cleanup; `flush().ok()` is the critical one)
- **Philosophy violation**: Zero-BS (errors should not be silently hidden)

Co-Authored-By: Copilot <noreply@github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)