### PR TITLE
audit(test): add proptest fuzz tests for condition evaluator

### DIFF
--- a/proptest-regressions/condition.txt
+++ b/proptest-regressions/condition.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 644cfc7367a91f0db96c652fc42c0fbc4ee86825e22f148860cdc560ba51e5bc # shrinks to var = "__", val = ""
+cc 5cb1cef0d27c5aa9247bd59f51c9cdb41361d28d253692d9e21793401e511cf3 # shrinks to var = "or", items = ["0"]

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1317,9 +1317,24 @@ mod tests {
         // avoids keywords (and, or, not, in, len, true, false, none).
         fn safe_var() -> impl Strategy<Value = String> {
             prop::sample::select(vec![
-                "status", "flag", "count", "name", "path", "val", "x", "y",
-                "task_type", "checkpoint", "scope", "items", "config",
-                "my_var", "result", "mode", "level", "step_id",
+                "status",
+                "flag",
+                "count",
+                "name",
+                "path",
+                "val",
+                "x",
+                "y",
+                "task_type",
+                "checkpoint",
+                "scope",
+                "items",
+                "config",
+                "my_var",
+                "result",
+                "mode",
+                "level",
+                "step_id",
             ])
             .prop_map(String::from)
         }

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1306,4 +1306,136 @@ mod tests {
             msg
         );
     }
+
+    // ---- proptest fuzz tests ----
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        // Safe variable name: starts with a letter, no consecutive underscores,
+        // avoids keywords (and, or, not, in, len, true, false, none).
+        fn safe_var() -> impl Strategy<Value = String> {
+            prop::sample::select(vec![
+                "status", "flag", "count", "name", "path", "val", "x", "y",
+                "task_type", "checkpoint", "scope", "items", "config",
+                "my_var", "result", "mode", "level", "step_id",
+            ])
+            .prop_map(String::from)
+        }
+
+        // Arbitrary string never panics the condition evaluator.
+        proptest! {
+            #[test]
+            fn fuzz_evaluate_never_panics(s in "\\PC{0,200}") {
+                let data: HashMap<String, Value> = HashMap::new();
+                let _ = evaluate_condition(&s, &data);
+            }
+        }
+
+        // Tokenizer never panics on arbitrary input.
+        proptest! {
+            #[test]
+            fn fuzz_tokenize_never_panics(s in "\\PC{0,200}") {
+                let _ = tokenize(&s);
+            }
+        }
+
+        // Conditions exceeding MAX_CONDITION_LEN always return an error.
+        proptest! {
+            #[test]
+            fn overlong_conditions_rejected(s in ".{8193,9000}") {
+                let data: HashMap<String, Value> = HashMap::new();
+                let result = evaluate_condition(&s, &data);
+                prop_assert!(result.is_err(), "overlong condition must be rejected");
+                let msg = result.unwrap_err().to_string();
+                prop_assert!(msg.contains("too long"), "error should mention length: {}", msg);
+            }
+        }
+
+        // Evaluation is deterministic: calling twice yields the same result.
+        proptest! {
+            #[test]
+            fn evaluate_is_deterministic(
+                var in safe_var(),
+                val in "[a-z]{1,5}",
+            ) {
+                let condition = format!("{} == '{}'", var, val);
+                let data = ctx(&[(&*var, serde_json::json!("hello"))]);
+                let r1 = evaluate_condition(&condition, &data);
+                let r2 = evaluate_condition(&condition, &data);
+                match (r1, r2) {
+                    (Ok(a), Ok(b)) => prop_assert_eq!(a, b),
+                    (Err(_), Err(_)) => {},
+                    (a, b) => prop_assert!(false, "mismatch: {:?} vs {:?}", a, b),
+                }
+            }
+        }
+
+        // Simple equality conditions with string variables always parse and
+        // evaluate correctly.
+        proptest! {
+            #[test]
+            fn simple_equality_never_panics(
+                var in safe_var(),
+                val in "[a-zA-Z0-9]{1,20}",
+            ) {
+                let condition = format!("{} == '{}'", var, val);
+                let data = ctx(&[(&*var, serde_json::json!(val.clone()))]);
+                let result = evaluate_condition(&condition, &data);
+                prop_assert!(result.is_ok(), "simple equality should parse: {:?}", result);
+                prop_assert!(result.unwrap(), "var == 'val' should be true when var contains val");
+            }
+        }
+
+        // `in` list conditions parse and evaluate correctly.
+        proptest! {
+            #[test]
+            fn in_list_never_panics(
+                var in safe_var(),
+                items in prop::collection::vec("[a-zA-Z0-9]{1,10}", 1..5),
+            ) {
+                let list = items.iter().map(|s| format!("'{}'", s)).collect::<Vec<_>>().join(", ");
+                let condition = format!("{} in [{}]", var, list);
+                let data = ctx(&[(&*var, serde_json::json!(items[0].clone()))]);
+                let result = evaluate_condition(&condition, &data);
+                prop_assert!(result.is_ok(), "in-list should parse: {:?}", result);
+                prop_assert!(result.unwrap(), "var should be in list when it contains var's value");
+            }
+        }
+
+        // Boolean connectives (and/or) with valid sub-conditions never panic.
+        proptest! {
+            #[test]
+            fn boolean_connectives_never_panic(
+                a_val in "[a-z]{1,5}",
+                b_val in "[a-z]{1,5}",
+                op in prop::sample::select(vec!["and", "or"]),
+            ) {
+                let condition = format!("x == '{}' {} y == '{}'", a_val, op, b_val);
+                let data = ctx(&[
+                    ("x", serde_json::json!(a_val)),
+                    ("y", serde_json::json!(b_val)),
+                ]);
+                let result = evaluate_condition(&condition, &data);
+                prop_assert!(result.is_ok(), "bool connective should parse: {:?}", result);
+            }
+        }
+
+        // `not in` conditions parse correctly.
+        proptest! {
+            #[test]
+            fn not_in_list_never_panics(
+                var in safe_var(),
+                items in prop::collection::vec("[a-zA-Z0-9]{1,10}", 1..5),
+            ) {
+                let list = items.iter().map(|s| format!("'{}'", s)).collect::<Vec<_>>().join(", ");
+                let condition = format!("{} not in [{}]", var, list);
+                let data = ctx(&[(&*var, serde_json::json!("ZZZZ_ABSENT"))]);
+                let result = evaluate_condition(&condition, &data);
+                prop_assert!(result.is_ok(), "not-in should parse: {:?}", result);
+                prop_assert!(result.unwrap(), "var not in list should be true when value is absent");
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

**Audit finding**: The condition evaluator (tokenizer + recursive-descent parser) had no property-based tests. The parser, context, progress_validator, and sub_recipe_recovery modules all have extensive proptest coverage (PRs #108, #109), but the condition evaluator — which handles arbitrary user-provided expressions — was only covered by hand-written unit tests.

**Fix**: Add 8 proptest cases covering:
- **Crash resistance**: arbitrary unicode input never panics the tokenizer or evaluator
- **Length enforcement**: expressions >8192 bytes are always rejected
- **Determinism**: same input always produces same result
- **Constructive**: generated equality, `in`, `not in`, and boolean connective expressions always parse and evaluate correctly

Uses a `safe_var()` strategy to avoid language keywords and dunder identifiers which are intentionally rejected by the safety layer.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — all 95 integration tests pass + 8 new proptests
- [x] Each proptest runs 256 cases by default

## Audit context

- **Category**: Formal correctness / property-based testing gap
- **Severity**: Low (no bugs found, but fuzz coverage was missing for a security-sensitive parser)
- **Philosophy**: Provable correctness via randomized testing

Co-Authored-By: Copilot <noreply@github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)