### PR TITLE
fix(runner): anchor sub-recipe resolution to recipe origin and working dir (rysweet/amplihack-rs#480)

### DIFF
--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -48,6 +48,23 @@ fn default_search_dirs() -> Vec<PathBuf> {
             }
         }
     }
+
+    // AMPLIHACK_HOME: the user's amplihack installation root (set by the
+    // amplihack-cli launcher and consumed by recipes that need to locate
+    // bundled assets). Derived from this is the per-install recipe dir,
+    // which the CLI-side `amplihack recipe list` already searches.
+    // Including it here brings runtime sub-recipe resolution into parity
+    // with `recipe list` (issue rysweet/amplihack-rs#480).
+    if let Ok(amplihack_home) = std::env::var("AMPLIHACK_HOME")
+        && !amplihack_home.is_empty()
+    {
+        dirs.push(
+            PathBuf::from(amplihack_home)
+                .join("amplifier-bundle")
+                .join("recipes"),
+        );
+    }
+
     dirs.extend([
         // Installed amplihack bundle (current layout)
         home.join(".amplihack")

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,6 +359,16 @@ fn run() -> i32 {
         .with_recipe_search_dirs(cli.recipe_dirs.into_iter().map(PathBuf::from).collect())
         .with_tags(cli.include_tags, cli.exclude_tags);
 
+    // Anchor sub-recipe resolution to the directory holding the top-level
+    // recipe file. Without this, sub-recipes co-located with the parent
+    // recipe are unfindable when the runner subprocess's cwd differs from
+    // the invocation directory (issue rysweet/amplihack-rs#480).
+    if let Some(parent) = resolved_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        runner = runner.with_recipe_origin_dir(parent.to_path_buf());
+    }
+
     if let Some(ref audit_dir) = cli.audit_dir {
         runner = runner.with_audit_dir(audit_dir.clone());
     }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6,6 +6,7 @@
 pub mod audit;
 pub mod json_parser;
 pub mod listeners;
+pub mod sub_recipe_paths;
 
 use crate::adapters::Adapter;
 use crate::agent_resolver::{AgentResolveError, AgentResolver};
@@ -46,6 +47,11 @@ pub struct RecipeRunner<A: Adapter> {
     max_depth: Cell<u32>,
     max_total_steps: Cell<u32>,
     recipe_search_dirs: Vec<PathBuf>,
+    /// Directory containing the top-level recipe file that was loaded at
+    /// runner entry. Used as the highest-priority anchor when resolving
+    /// sub-recipes referenced by `recipe:`-typed steps. See
+    /// [`sub_recipe_paths::anchored_search_dirs`].
+    recipe_origin_dir: Option<PathBuf>,
     audit_dir: Option<PathBuf>,
     active_tags: Vec<String>,
     exclude_tags: Vec<String>,
@@ -70,6 +76,7 @@ impl<A: Adapter> RecipeRunner<A> {
             max_depth: Cell::new(DEFAULT_MAX_DEPTH),
             max_total_steps: Cell::new(200),
             recipe_search_dirs: Vec::new(),
+            recipe_origin_dir: None,
             audit_dir: None,
             active_tags: Vec::new(),
             exclude_tags: Vec::new(),
@@ -106,6 +113,18 @@ impl<A: Adapter> RecipeRunner<A> {
     pub fn with_recipe_search_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
         log::debug!("RecipeRunner::with_recipe_search_dirs: {} dirs", dirs.len());
         self.recipe_search_dirs = dirs;
+        self
+    }
+
+    /// Set the directory containing the top-level recipe file (typically the
+    /// parent of the file path passed to `recipe-runner-rs`). This anchors
+    /// sub-recipe resolution to the same location the user invoked the
+    /// recipe from, so a sub-recipe co-located with its parent is found
+    /// even when `recipe-runner-rs`'s subprocess `cwd` differs from the
+    /// invocation directory. See issue rysweet/amplihack-rs#480.
+    pub fn with_recipe_origin_dir(mut self, dir: PathBuf) -> Self {
+        log::debug!("RecipeRunner::with_recipe_origin_dir: dir={:?}", dir);
+        self.recipe_origin_dir = Some(dir);
         self
     }
 
@@ -778,7 +797,11 @@ impl<A: Adapter> RecipeRunner<A> {
             .find_recipe_path(recipe_name)
             .ok_or_else(|| StepExecutionError {
                 step_id: step.id.clone(),
-                message: format!("Sub-recipe '{}' not found", recipe_name),
+                message: format!(
+                    "Sub-recipe '{}' not found. Searched the following directories (in order):\n{}",
+                    recipe_name,
+                    self.sub_recipe_search_diagnostic()
+                ),
             })?;
 
         let parser = RecipeParser::new();
@@ -943,25 +966,108 @@ impl<A: Adapter> RecipeRunner<A> {
 
     fn find_recipe_path(&self, name: &str) -> Option<String> {
         log::debug!("find_recipe_path: name={:?}", name);
-        // First try discovery module
+        // Security: reject names with path separators / parent-dir markers
+        // before any filesystem resolution. Failures bubble up as part of
+        // the Zero-BS diagnostic emitted by the caller.
+        if let Err(reason) = sub_recipe_paths::validate_sub_recipe_name(name) {
+            log::warn!(
+                "find_recipe_path: rejecting unsafe sub-recipe name {:?}: {}",
+                name,
+                reason
+            );
+            return None;
+        }
+
+        // 1. Explicit user-provided search dirs win first (matches the prior
+        //    behavior; preserves -R / --recipe-dir override semantics).
         if !self.recipe_search_dirs.is_empty()
             && let Some(path) = discovery::find_recipe(name, Some(&self.recipe_search_dirs))
         {
             return Some(path.display().to_string());
         }
 
-        // Fall back to discovery module default paths
+        // 2. Anchored search: recipe-local → working_dir → walk-up to .git.
+        //    These dirs are computed from the runner's `working_dir` (-C
+        //    arg) rather than the subprocess cwd, so resolution is stable
+        //    regardless of how `recipe-runner-rs` was invoked.
+        let anchored = sub_recipe_paths::anchored_search_dirs(
+            self.recipe_origin_dir.as_deref(),
+            Path::new(&self.working_dir),
+        );
+        if !anchored.is_empty()
+            && let Some(path) = discovery::find_recipe(name, Some(&anchored))
+        {
+            // Defense in depth: ensure the resolved file physically lives
+            // within one of the anchored roots, so a symlink in those roots
+            // cannot be used to read an arbitrary file off the filesystem.
+            if sub_recipe_paths::is_within_any(&path, &anchored) {
+                return Some(path.display().to_string());
+            }
+            log::warn!(
+                "find_recipe_path: rejecting candidate {} — resolves outside anchored search roots",
+                path.display()
+            );
+        }
+
+        // 3. Fall back to discovery module's default search dirs
+        //    (~/.amplihack, $AMPLIHACK_HOME, etc.).
         if let Some(path) = discovery::find_recipe(name, None) {
             return Some(path.display().to_string());
         }
 
-        // Finally check working directory
-        let filename = format!("{}.yaml", name);
-        let local = Path::new(&self.working_dir).join(&filename);
-        if local.is_file() {
-            return Some(local.display().to_string());
-        }
         None
+    }
+
+    /// Build the human-readable list of directories that were consulted while
+    /// trying to resolve a sub-recipe. Used to produce a Zero-BS diagnostic
+    /// when resolution fails — the user must be told exactly where we looked
+    /// (paths only; no raw env-var values, to avoid leaking secrets).
+    fn sub_recipe_search_diagnostic(&self) -> String {
+        let mut all: Vec<PathBuf> = Vec::new();
+        all.extend(self.recipe_search_dirs.iter().cloned());
+        all.extend(sub_recipe_paths::anchored_search_dirs(
+            self.recipe_origin_dir.as_deref(),
+            Path::new(&self.working_dir),
+        ));
+        // The discovery module's defaults are private, but their contents
+        // are stable and documented; enumerate them here so the diagnostic
+        // is complete without exposing internal helpers.
+        if let Some(home) = dirs::home_dir() {
+            all.push(home.join(".amplihack").join("amplifier-bundle").join("recipes"));
+            all.push(home.join(".amplihack").join(".claude").join("recipes"));
+        }
+        if let Ok(amplihack_home) = std::env::var("AMPLIHACK_HOME")
+            && !amplihack_home.is_empty()
+        {
+            all.push(
+                PathBuf::from(amplihack_home)
+                    .join("amplifier-bundle")
+                    .join("recipes"),
+            );
+        }
+        all.push(PathBuf::from("amplifier-bundle").join("recipes"));
+        all.push(
+            PathBuf::from("src")
+                .join("amplihack")
+                .join("amplifier-bundle")
+                .join("recipes"),
+        );
+        all.push(PathBuf::from(".claude").join("recipes"));
+
+        // De-dupe while preserving order.
+        let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+        let mut lines = String::new();
+        for d in all {
+            if seen.insert(d.clone()) {
+                lines.push_str("  - ");
+                lines.push_str(&d.display().to_string());
+                if !d.is_dir() {
+                    lines.push_str(" (does not exist)");
+                }
+                lines.push('\n');
+            }
+        }
+        lines
     }
 
     /// Retry an agent step with an explicit JSON-only instruction.

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1033,7 +1033,11 @@ impl<A: Adapter> RecipeRunner<A> {
         // are stable and documented; enumerate them here so the diagnostic
         // is complete without exposing internal helpers.
         if let Some(home) = dirs::home_dir() {
-            all.push(home.join(".amplihack").join("amplifier-bundle").join("recipes"));
+            all.push(
+                home.join(".amplihack")
+                    .join("amplifier-bundle")
+                    .join("recipes"),
+            );
             all.push(home.join(".amplihack").join(".claude").join("recipes"));
         }
         if let Ok(amplihack_home) = std::env::var("AMPLIHACK_HOME")

--- a/src/runner/sub_recipe_paths.rs
+++ b/src/runner/sub_recipe_paths.rs
@@ -172,7 +172,16 @@ mod tests {
 
     #[test]
     fn validate_rejects_path_traversal() {
-        for bad in ["", ".hidden", "..", "../escape", "a/b", "a\\b", "a..b", "a b"] {
+        for bad in [
+            "",
+            ".hidden",
+            "..",
+            "../escape",
+            "a/b",
+            "a\\b",
+            "a..b",
+            "a b",
+        ] {
             assert!(
                 validate_sub_recipe_name(bad).is_err(),
                 "must reject: {bad:?}"
@@ -221,7 +230,8 @@ mod tests {
         let dirs = anchored_search_dirs(None, &nested);
         let canonical_bundle = bundle.canonicalize().unwrap();
         assert!(
-            dirs.iter().any(|d| d.canonicalize().ok() == Some(canonical_bundle.clone())),
+            dirs.iter()
+                .any(|d| d.canonicalize().ok() == Some(canonical_bundle.clone())),
             "expected walk-up to find repo-root bundle; got: {dirs:?}"
         );
     }

--- a/src/runner/sub_recipe_paths.rs
+++ b/src/runner/sub_recipe_paths.rs
@@ -1,0 +1,312 @@
+//! Anchored search-path resolution for sub-recipes.
+//!
+//! When a top-level recipe references a sub-recipe by name, the runner needs
+//! to find that sub-recipe in directories that are *anchored* to the location
+//! the user invoked the recipe from — not just the global default search
+//! directories. This module provides:
+//!
+//! * [`validate_sub_recipe_name`] — security primitive that rejects names
+//!   containing path separators, parent-dir markers, or absolute prefixes.
+//! * [`is_within_any`] — canonicalized containment check that prevents
+//!   symlink-based escapes from a candidate file.
+//! * [`walk_up_to_git`] — bounded ascent (10 ancestors) from a starting
+//!   directory toward a `.git` marker, returning intermediate ancestors.
+//! * [`anchored_search_dirs`] — composes the ordered list of dirs to search:
+//!   recipe-local → working_dir/amplifier-bundle/recipes → walk-up
+//!   ancestors/amplifier-bundle/recipes.
+//!
+//! These helpers are intentionally pure (no I/O beyond filesystem stat) so
+//! they can be unit-tested in isolation.
+
+use std::path::{Path, PathBuf};
+
+/// Maximum number of ancestor directories inspected when walking up looking
+/// for a `.git` marker. Bounded to defend against pathological symlink loops
+/// and runaway traversal on systems with deeply nested mounts.
+pub(crate) const WALK_UP_MAX_ANCESTORS: usize = 10;
+
+/// Reject sub-recipe names that could escape the search directory.
+///
+/// Acceptance: `^[A-Za-z0-9_-]+$`. This is intentionally stricter than
+/// [`crate::discovery::find_recipe`]'s `is_safe_recipe_name` because callers
+/// at the runner layer are programmatic (recipe authors writing
+/// `recipe: "<name>"` step fields) and have no legitimate reason to use
+/// dotted names, mixed extensions, or anything else exotic.
+///
+/// Returns `Ok(())` if the name is acceptable, or `Err(reason)` otherwise.
+/// The error string is suitable for inclusion in a Zero-BS diagnostic.
+pub(crate) fn validate_sub_recipe_name(name: &str) -> Result<(), &'static str> {
+    if name.is_empty() {
+        return Err("sub-recipe name is empty");
+    }
+    if name.starts_with('.') {
+        return Err("sub-recipe name must not start with '.'");
+    }
+    if name.contains("..") {
+        return Err("sub-recipe name must not contain '..'");
+    }
+    for c in name.chars() {
+        let ok = c.is_ascii_alphanumeric() || c == '_' || c == '-';
+        if !ok {
+            return Err(
+                "sub-recipe name must match [A-Za-z0-9_-]+ (no path separators, NUL bytes, or whitespace)",
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Return true if `candidate` resolves (after canonicalization) to a path
+/// inside any of `roots`. Used to guarantee that a resolved sub-recipe file
+/// physically lives within one of the anchored search directories — even if
+/// a symlink in that directory points elsewhere.
+///
+/// If either side fails to canonicalize (e.g., the file does not exist),
+/// returns `false` — the caller should treat that as "not found within any
+/// permitted root" and continue looking.
+pub(crate) fn is_within_any(candidate: &Path, roots: &[PathBuf]) -> bool {
+    let canonical_candidate = match candidate.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    for root in roots {
+        if let Ok(canonical_root) = root.canonicalize()
+            && canonical_candidate.starts_with(&canonical_root)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Walk up from `start` collecting ancestor directories, stopping when a
+/// `.git` marker is encountered (the walk includes that ancestor) or when
+/// [`WALK_UP_MAX_ANCESTORS`] is reached.
+///
+/// The walk is bounded to defend against pathological symlink loops and
+/// avoids ascending into the filesystem root indefinitely.
+///
+/// Returns ancestors in order from `start` outward. `start` itself is the
+/// first element if it is a directory.
+pub(crate) fn walk_up_to_git(start: &Path) -> Vec<PathBuf> {
+    let mut acc = Vec::new();
+    let mut current = match start.canonicalize() {
+        Ok(p) => p,
+        Err(_) => start.to_path_buf(),
+    };
+
+    for _ in 0..WALK_UP_MAX_ANCESTORS {
+        acc.push(current.clone());
+        if current.join(".git").exists() {
+            return acc;
+        }
+        match current.parent() {
+            Some(parent) if parent != current => current = parent.to_path_buf(),
+            _ => break,
+        }
+    }
+    acc
+}
+
+/// Compose the ordered list of anchored sub-recipe search directories.
+///
+/// Order:
+///   1. `recipe_origin_dir` — directory containing the top-level recipe file
+///      that was loaded at runner entry. Sub-recipes co-located with their
+///      parent recipe are the most natural reference.
+///   2. `working_dir/amplifier-bundle/recipes` — project-relative recipes
+///      anchored at the user-supplied `-C` working directory (NOT the
+///      runner subprocess's actual cwd, which can drift).
+///   3. For each ancestor of `working_dir` discovered by [`walk_up_to_git`]:
+///      `<ancestor>/amplifier-bundle/recipes`. This catches the case where
+///      the user invokes the runner from a subdirectory of a repo that has
+///      `amplifier-bundle/recipes` at its root.
+///
+/// Duplicates are de-duplicated while preserving first-seen order.
+/// Non-directory entries are filtered out.
+pub(crate) fn anchored_search_dirs(
+    recipe_origin_dir: Option<&Path>,
+    working_dir: &Path,
+) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let push_unique = |dirs: &mut Vec<PathBuf>, p: PathBuf| {
+        if p.is_dir() && !dirs.iter().any(|existing| existing == &p) {
+            dirs.push(p);
+        }
+    };
+
+    if let Some(origin) = recipe_origin_dir {
+        push_unique(&mut dirs, origin.to_path_buf());
+    }
+
+    // The runner's working_dir itself, so that a bare `<name>.yaml` next
+    // to the working dir is discoverable (preserves a niche fallback from
+    // the pre-#480 implementation while keeping it inside the
+    // canonicalized-containment perimeter).
+    push_unique(&mut dirs, working_dir.to_path_buf());
+
+    let working_bundle = working_dir.join("amplifier-bundle").join("recipes");
+    push_unique(&mut dirs, working_bundle);
+
+    for ancestor in walk_up_to_git(working_dir) {
+        let candidate = ancestor.join("amplifier-bundle").join("recipes");
+        push_unique(&mut dirs, candidate);
+    }
+
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_normal_names() {
+        for name in ["smart-classify-route", "workflow_prep", "abc123", "x"] {
+            assert!(
+                validate_sub_recipe_name(name).is_ok(),
+                "must accept: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_path_traversal() {
+        for bad in ["", ".hidden", "..", "../escape", "a/b", "a\\b", "a..b", "a b"] {
+            assert!(
+                validate_sub_recipe_name(bad).is_err(),
+                "must reject: {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_nul_byte() {
+        assert!(validate_sub_recipe_name("a\0b").is_err());
+    }
+
+    #[test]
+    fn anchored_dirs_includes_recipe_origin_first() {
+        let tmp = tempfile::tempdir().unwrap();
+        let origin = tmp.path().join("origin");
+        std::fs::create_dir_all(&origin).unwrap();
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).unwrap();
+
+        let dirs = anchored_search_dirs(Some(&origin), &work);
+        assert_eq!(dirs.first().unwrap(), &origin);
+    }
+
+    #[test]
+    fn anchored_dirs_includes_working_dir_bundle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().to_path_buf();
+        let bundle = work.join("amplifier-bundle").join("recipes");
+        std::fs::create_dir_all(&bundle).unwrap();
+
+        let dirs = anchored_search_dirs(None, &work);
+        assert!(dirs.contains(&bundle), "got: {dirs:?}");
+    }
+
+    #[test]
+    fn anchored_dirs_walks_up_to_repo_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path();
+        std::fs::create_dir_all(repo_root.join(".git")).unwrap();
+        let bundle = repo_root.join("amplifier-bundle").join("recipes");
+        std::fs::create_dir_all(&bundle).unwrap();
+        let nested = repo_root.join("crates").join("subproject");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let dirs = anchored_search_dirs(None, &nested);
+        let canonical_bundle = bundle.canonicalize().unwrap();
+        assert!(
+            dirs.iter().any(|d| d.canonicalize().ok() == Some(canonical_bundle.clone())),
+            "expected walk-up to find repo-root bundle; got: {dirs:?}"
+        );
+    }
+
+    #[test]
+    fn anchored_dirs_dedupes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().to_path_buf();
+        let bundle = work.join("amplifier-bundle").join("recipes");
+        std::fs::create_dir_all(&bundle).unwrap();
+
+        // origin == working_bundle would otherwise produce a duplicate
+        let dirs = anchored_search_dirs(Some(&bundle), &work);
+        let count = dirs.iter().filter(|d| *d == &bundle).count();
+        assert_eq!(count, 1, "must dedupe; got: {dirs:?}");
+    }
+
+    #[test]
+    fn walk_up_bounded_at_max_ancestors() {
+        // Build a deeply nested structure with no .git marker and verify
+        // we stop after WALK_UP_MAX_ANCESTORS ascents.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut path = tmp.path().to_path_buf();
+        for i in 0..(WALK_UP_MAX_ANCESTORS + 5) {
+            path = path.join(format!("d{i}"));
+        }
+        std::fs::create_dir_all(&path).unwrap();
+        let walk = walk_up_to_git(&path);
+        assert!(
+            walk.len() <= WALK_UP_MAX_ANCESTORS,
+            "walk_up_to_git must be bounded; got {} ancestors",
+            walk.len()
+        );
+    }
+
+    #[test]
+    fn walk_up_stops_at_git_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        let nested = repo.join("a").join("b");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let walk = walk_up_to_git(&nested);
+        let canonical_repo = repo.canonicalize().unwrap();
+        let last = walk.last().unwrap().canonicalize().unwrap();
+        assert_eq!(last, canonical_repo, "must stop at .git marker");
+    }
+
+    #[test]
+    fn is_within_any_accepts_real_containment() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let file = root.join("foo.yaml");
+        std::fs::write(&file, "x").unwrap();
+        assert!(is_within_any(&file, &[root]));
+    }
+
+    #[test]
+    fn is_within_any_rejects_nonexistent() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!is_within_any(
+            &tmp.path().join("does-not-exist.yaml"),
+            &[tmp.path().to_path_buf()]
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn is_within_any_rejects_symlink_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("permitted");
+        std::fs::create_dir_all(&root).unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let secret = outside.join("secret.yaml");
+        std::fs::write(&secret, "x").unwrap();
+
+        // Symlink inside `root` that points outside.
+        let link = root.join("escape.yaml");
+        std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+        assert!(
+            !is_within_any(&link, &[root]),
+            "containment check must canonicalize and reject symlink escapes"
+        );
+    }
+}

--- a/tests/sub_recipe_resolution_test.rs
+++ b/tests/sub_recipe_resolution_test.rs
@@ -93,7 +93,11 @@ fn sub_recipe_resolves_from_recipe_origin_dir() {
     assert!(
         result.success,
         "sub-recipe must resolve from recipe-origin dir; got: {:?}",
-        result.step_results.iter().map(|s| (&s.step_id, &s.status)).collect::<Vec<_>>()
+        result
+            .step_results
+            .iter()
+            .map(|s| (&s.step_id, &s.status))
+            .collect::<Vec<_>>()
     );
 }
 
@@ -110,10 +114,13 @@ fn sub_recipe_resolves_from_working_dir_bundle() {
 
     let parser = RecipeParser::new();
     let recipe = parser.parse_file(&parent_path).unwrap();
-    let runner = RecipeRunner::new(NoopAdapter)
-        .with_working_dir(project_root.path().to_str().unwrap());
+    let runner =
+        RecipeRunner::new(NoopAdapter).with_working_dir(project_root.path().to_str().unwrap());
     let result = runner.execute(&recipe, None);
-    assert!(result.success, "sub-recipe must resolve via working_dir/amplifier-bundle/recipes");
+    assert!(
+        result.success,
+        "sub-recipe must resolve via working_dir/amplifier-bundle/recipes"
+    );
 }
 
 /// (c) Walk-up resolution: parent invoked from a subdir of a repo whose root
@@ -233,12 +240,8 @@ fn sub_recipe_symlink_escape_is_rejected() {
     // search dir (e.g. ~/.amplihack/amplifier-bundle/recipes), so that
     // resolution failure unambiguously tests the containment check.
     let unique = format!("sym-escape-{}", std::process::id());
-    let parent_yaml = format!(
-        "name: parent\nsteps:\n  - id: dispatch\n    recipe: \"{unique}\"\n"
-    );
-    let child_yaml = format!(
-        "name: {unique}\nsteps:\n  - id: noop\n    command: \"echo\"\n"
-    );
+    let parent_yaml = format!("name: parent\nsteps:\n  - id: dispatch\n    recipe: \"{unique}\"\n");
+    let child_yaml = format!("name: {unique}\nsteps:\n  - id: noop\n    command: \"echo\"\n");
 
     let bundle_dir = tempfile::tempdir().unwrap();
     let outside = tempfile::tempdir().unwrap();

--- a/tests/sub_recipe_resolution_test.rs
+++ b/tests/sub_recipe_resolution_test.rs
@@ -1,0 +1,270 @@
+//! Regression tests for sub-recipe resolution.
+//!
+//! Issue: rysweet/amplihack-rs#480 — `smart-orchestrator` and `default-workflow`
+//! could not locate the sub-recipes they reference (`smart-classify-route`,
+//! `workflow-prep`, …) because the runner only consulted
+//! [`recipe_runner_rs::discovery`]'s default search dirs, which are interpreted
+//! relative to the runner subprocess's actual `cwd`. When the CLI launcher
+//! invokes `recipe-runner-rs` from a directory other than the repo root, the
+//! `amplifier-bundle/recipes` sub-directory is not found and resolution fails
+//! with the unhelpful message `Sub-recipe '<name>' not found`.
+//!
+//! The fix anchors sub-recipe search to:
+//!   1. the directory containing the top-level recipe file (recipe origin),
+//!   2. the runner's `--working-dir` (`-C`) argument,
+//!   3. ancestors of the working dir up to a `.git` marker.
+//!
+//! These tests cover positive resolution paths from each anchor as well as
+//! negative cases that defend against path-traversal and symlink-escape.
+
+use recipe_runner_rs::adapters::Adapter;
+use recipe_runner_rs::parser::RecipeParser;
+use recipe_runner_rs::runner::RecipeRunner;
+
+/// Minimal adapter that records nothing — sub-recipe resolution happens at
+/// parse/dispatch time, before any agent or bash adapter call is made.
+struct NoopAdapter;
+
+impl Adapter for NoopAdapter {
+    fn execute_agent_step(
+        &self,
+        _prompt: &str,
+        _agent_name: Option<&str>,
+        _system_prompt: Option<&str>,
+        _mode: Option<&str>,
+        _working_dir: &str,
+        _model: Option<&str>,
+        _timeout: Option<u64>,
+    ) -> Result<String, anyhow::Error> {
+        Ok(String::new())
+    }
+    fn execute_bash_step(
+        &self,
+        _command: &str,
+        _working_dir: &str,
+        _timeout: Option<u64>,
+        _extra_env: &std::collections::HashMap<String, String>,
+    ) -> Result<String, anyhow::Error> {
+        Ok(String::new())
+    }
+    fn is_available(&self) -> bool {
+        true
+    }
+    fn name(&self) -> &str {
+        "noop"
+    }
+}
+
+const PARENT_RECIPE: &str = r#"
+name: parent-orchestrator
+description: A top-level recipe that references a sibling sub-recipe by name.
+steps:
+  - id: dispatch
+    recipe: "child-step"
+"#;
+
+const CHILD_RECIPE: &str = r#"
+name: child-step
+description: A sibling sub-recipe referenced from parent-orchestrator.
+steps:
+  - id: noop
+    command: "echo child-ran"
+"#;
+
+/// (a) Sub-recipe co-located with its parent must resolve via the
+/// recipe-origin anchor — even when the runner's working directory is
+/// somewhere completely different.
+#[test]
+fn sub_recipe_resolves_from_recipe_origin_dir() {
+    let recipes_dir = tempfile::tempdir().unwrap();
+    let parent_path = recipes_dir.path().join("parent-orchestrator.yaml");
+    std::fs::write(&parent_path, PARENT_RECIPE).unwrap();
+    std::fs::write(recipes_dir.path().join("child-step.yaml"), CHILD_RECIPE).unwrap();
+
+    let unrelated_cwd = tempfile::tempdir().unwrap();
+
+    let parser = RecipeParser::new();
+    let recipe = parser.parse_file(&parent_path).unwrap();
+    let runner = RecipeRunner::new(NoopAdapter)
+        .with_working_dir(unrelated_cwd.path().to_str().unwrap())
+        .with_recipe_origin_dir(recipes_dir.path().to_path_buf());
+    let result = runner.execute(&recipe, None);
+
+    assert!(
+        result.success,
+        "sub-recipe must resolve from recipe-origin dir; got: {:?}",
+        result.step_results.iter().map(|s| (&s.step_id, &s.status)).collect::<Vec<_>>()
+    );
+}
+
+/// (b) Sub-recipe under `<working_dir>/amplifier-bundle/recipes` must resolve
+/// even when the runner's subprocess `cwd` differs from `working_dir`.
+#[test]
+fn sub_recipe_resolves_from_working_dir_bundle() {
+    let project_root = tempfile::tempdir().unwrap();
+    let bundle = project_root.path().join("amplifier-bundle").join("recipes");
+    std::fs::create_dir_all(&bundle).unwrap();
+    let parent_path = bundle.join("parent-orchestrator.yaml");
+    std::fs::write(&parent_path, PARENT_RECIPE).unwrap();
+    std::fs::write(bundle.join("child-step.yaml"), CHILD_RECIPE).unwrap();
+
+    let parser = RecipeParser::new();
+    let recipe = parser.parse_file(&parent_path).unwrap();
+    let runner = RecipeRunner::new(NoopAdapter)
+        .with_working_dir(project_root.path().to_str().unwrap());
+    let result = runner.execute(&recipe, None);
+    assert!(result.success, "sub-recipe must resolve via working_dir/amplifier-bundle/recipes");
+}
+
+/// (c) Walk-up resolution: parent invoked from a subdir of a repo whose root
+/// holds `amplifier-bundle/recipes`. The resolver must climb to the `.git`
+/// marker and find the bundle there.
+#[test]
+fn sub_recipe_resolves_via_walk_up_to_git() {
+    let repo = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(repo.path().join(".git")).unwrap();
+    let bundle = repo.path().join("amplifier-bundle").join("recipes");
+    std::fs::create_dir_all(&bundle).unwrap();
+    std::fs::write(bundle.join("child-step.yaml"), CHILD_RECIPE).unwrap();
+
+    // Parent recipe lives elsewhere — we are testing repo-root discovery,
+    // not recipe-origin discovery. The runner's working dir is a deep subdir.
+    let recipe_dir = tempfile::tempdir().unwrap();
+    let parent_path = recipe_dir.path().join("parent.yaml");
+    std::fs::write(&parent_path, PARENT_RECIPE).unwrap();
+
+    let nested = repo.path().join("crates").join("subproject");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let parser = RecipeParser::new();
+    let recipe = parser.parse_file(&parent_path).unwrap();
+    let runner = RecipeRunner::new(NoopAdapter)
+        .with_working_dir(nested.to_str().unwrap())
+        // Recipe origin intentionally NOT set — exercise the walk-up path.
+        ;
+    let result = runner.execute(&recipe, None);
+    assert!(
+        result.success,
+        "sub-recipe must resolve by walking up from working_dir to .git root"
+    );
+}
+
+/// (d) Resolution failure must produce a Zero-BS diagnostic that lists every
+/// directory the runner consulted. No silent fallback.
+#[test]
+fn missing_sub_recipe_diagnostic_lists_all_search_dirs() {
+    let recipes_dir = tempfile::tempdir().unwrap();
+    let parent_path = recipes_dir.path().join("parent.yaml");
+    std::fs::write(&parent_path, PARENT_RECIPE).unwrap();
+    // Intentionally do NOT write child-step.yaml.
+
+    let parser = RecipeParser::new();
+    let recipe = parser.parse_file(&parent_path).unwrap();
+    let runner = RecipeRunner::new(NoopAdapter)
+        .with_working_dir(recipes_dir.path().to_str().unwrap())
+        .with_recipe_origin_dir(recipes_dir.path().to_path_buf());
+    let result = runner.execute(&recipe, None);
+
+    assert!(!result.success, "missing sub-recipe must fail the recipe");
+    let dispatch = result
+        .step_results
+        .iter()
+        .find(|s| s.step_id == "dispatch")
+        .expect("dispatch step result missing");
+    let err = dispatch.error.as_str();
+    assert!(
+        err.contains("Sub-recipe 'child-step' not found"),
+        "diagnostic must name the missing sub-recipe; got: {err}"
+    );
+    assert!(
+        err.contains("Searched the following directories"),
+        "diagnostic must enumerate searched dirs; got: {err}"
+    );
+    assert!(
+        err.contains(recipes_dir.path().to_str().unwrap()),
+        "diagnostic must include the recipe-origin dir; got: {err}"
+    );
+}
+
+/// (e) Negative — a sub-recipe name with traversal segments must be rejected
+/// at the validation layer, before any filesystem resolution. The error must
+/// not silently fall through to a different recipe.
+#[test]
+fn sub_recipe_name_with_traversal_is_rejected() {
+    let recipes_dir = tempfile::tempdir().unwrap();
+    let parent = r#"
+name: parent
+steps:
+  - id: dispatch
+    recipe: "../escape"
+"#;
+    let parent_path = recipes_dir.path().join("parent.yaml");
+    std::fs::write(&parent_path, parent).unwrap();
+
+    let parser = RecipeParser::new();
+    // The parser may either reject this at parse time (preferred) or accept
+    // it and let the runner reject it at dispatch time. Both outcomes are
+    // acceptable for the security guarantee — what is NOT acceptable is for
+    // resolution to succeed and read a file outside the search roots.
+    match parser.parse_file(&parent_path) {
+        Err(_) => {
+            // Parser-level rejection is fine.
+        }
+        Ok(recipe) => {
+            let runner = RecipeRunner::new(NoopAdapter)
+                .with_working_dir(recipes_dir.path().to_str().unwrap())
+                .with_recipe_origin_dir(recipes_dir.path().to_path_buf());
+            let result = runner.execute(&recipe, None);
+            assert!(!result.success, "name with '..' must not resolve");
+        }
+    }
+}
+
+/// (f) Negative (Unix only) — a symlink inside an anchored search dir that
+/// points to a file outside any anchored root must NOT resolve. This defends
+/// against an attacker placing a symlink in `amplifier-bundle/recipes/` to
+/// trick the runner into reading an arbitrary file.
+#[test]
+#[cfg(unix)]
+fn sub_recipe_symlink_escape_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    // Use a unique recipe name that cannot exist in any global default
+    // search dir (e.g. ~/.amplihack/amplifier-bundle/recipes), so that
+    // resolution failure unambiguously tests the containment check.
+    let unique = format!("sym-escape-{}", std::process::id());
+    let parent_yaml = format!(
+        "name: parent\nsteps:\n  - id: dispatch\n    recipe: \"{unique}\"\n"
+    );
+    let child_yaml = format!(
+        "name: {unique}\nsteps:\n  - id: noop\n    command: \"echo\"\n"
+    );
+
+    let bundle_dir = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+
+    // Place a "real" recipe outside the search root.
+    let secret = outside.path().join(format!("{unique}.yaml"));
+    std::fs::write(&secret, child_yaml).unwrap();
+
+    // And a symlink inside the search root pointing at it.
+    symlink(&secret, bundle_dir.path().join(format!("{unique}.yaml"))).unwrap();
+
+    let parent_path = bundle_dir.path().join("parent.yaml");
+    std::fs::write(&parent_path, parent_yaml).unwrap();
+
+    let parser = RecipeParser::new();
+    let recipe = parser.parse_file(&parent_path).unwrap();
+    let runner = RecipeRunner::new(NoopAdapter)
+        .with_working_dir(bundle_dir.path().to_str().unwrap())
+        .with_recipe_origin_dir(bundle_dir.path().to_path_buf());
+    let result = runner.execute(&recipe, None);
+
+    // The containment check rejects the symlink; resolution falls through to
+    // discovery defaults (which won't find it either) and fails with the
+    // Zero-BS diagnostic.
+    assert!(
+        !result.success,
+        "symlink that escapes anchored roots must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes [rysweet/amplihack-rs#480](https://github.com/rysweet/amplihack-rs/issues/480): `smart-orchestrator` and `default-workflow` cannot find their registered sub-recipes (`smart-classify-route`, `workflow-prep`, …) at runtime, even though `amplihack recipe list` enumerates them correctly.

## Root cause

`RecipeRunner::find_recipe_path` only consulted `discovery::default_search_dirs`, whose relative entries (`amplifier-bundle/recipes`, `.claude/recipes`) are evaluated against the runner subprocess's actual `cwd`. The `amplihack-cli` launcher invokes `recipe-runner-rs` from a directory that frequently differs from where the user ran `amplihack recipe run …`, so the bundle is invisible. The bug never reproduced for top-level recipe lookup because `amplihack-cli` resolves the top-level path itself before invoking the runner.

## Fix

`find_recipe_path` now searches, in order:

1. Explicit `-R` / `--recipe-dir` overrides (unchanged).
2. **Anchored search**:
   - directory containing the loaded top-level recipe (recipe origin),
   - the runner's `-C` working directory itself,
   - `<working_dir>/amplifier-bundle/recipes`,
   - each ancestor of `working_dir` up to a `.git` marker (bounded to 10 hops) joined with `amplifier-bundle/recipes`.
3. `discovery::default_search_dirs` (now also honors `AMPLIHACK_HOME` for parity with `amplihack-cli`).

The recipe-origin anchor is wired from `src/main.rs` (`with_recipe_origin_dir(parent_of_resolved_recipe_path)`).

## Security

- `validate_sub_recipe_name` (`^[A-Za-z0-9_-]+$`) rejects path-traversal, hidden names, NUL bytes, and whitespace **before** any filesystem resolution.
- `is_within_any` canonicalizes both candidate and anchored roots, so a symlink planted inside an anchored search dir cannot exfiltrate an arbitrary file.
- `walk_up_to_git` is bounded to 10 ancestors to defend against pathological loops.

## Zero-BS diagnostic

When resolution fails, the error now enumerates every directory consulted (paths only, no raw env-var values).

## Test plan

- New `tests/sub_recipe_resolution_test.rs` (6 tests): (a) recipe-origin (b) working-dir bundle (c) walk-up-to-.git (d) diagnostic content (e) name-traversal rejection (f) symlink-escape rejection.
- All 640 existing tests continue to pass.
- `cargo clippy -p recipe-runner-rs --all-targets -- -D warnings` clean.

## Out of scope

Per the issue's clarified requirements: no recipe YAML changes, no `verification-workflow` modifications, no schema refactor.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
