### PR TITLE
ci: harden supply chain (SHA-pin actions, least-privilege tokens, cargo-deny gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,23 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default for GITHUB_TOKEN. Every job here only needs to read
+# the repository contents; no job pushes commits, comments, or releases.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -38,8 +43,8 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
       - run: cargo clippy --all-targets -- -D warnings
@@ -48,8 +53,8 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - run: cargo fmt --check
@@ -58,13 +63,13 @@ jobs:
     name: Validate Self-Building Recipe
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -110,24 +115,28 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install cargo-audit
-        run: cargo install cargo-audit --quiet
-      - name: Run security audit
+        run: cargo install cargo-audit --version 0.22.2 --locked
+      - name: Run security audit (RustSec advisory DB)
         run: cargo audit
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version 0.19.9 --locked
+      - name: Run cargo-deny (advisories, bans, licenses, sources)
+        run: cargo deny check
 
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -136,7 +145,7 @@ jobs:
           key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
 
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin --quiet
+        run: cargo install cargo-tarpaulin --version 0.36.0 --locked
 
       - name: Run coverage
         run: cargo tarpaulin --all-targets --out stdout --skip-clean 2>&1 | tee coverage.txt

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+# Deny-all default; the single job below grants itself the read scope it needs.
+permissions: {}
+
 jobs:
   # The job MUST be called 'copilot-setup-steps' to be recognized by GitHub Copilot Agent
   copilot-setup-steps:
@@ -23,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install gh-aw extension
         uses: github/gh-aw/actions/setup-cli@f1073c5498ee46fec1530555a7c953445417c69b # v0.56.2
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,10 +9,11 @@ on:
       - 'README.md'
       - 'examples/**'
 
+# Least-privilege default: the build job only needs to read the repo. The
+# Pages-deployment scopes (pages: write / id-token: write) are granted to the
+# deploy job alone, below.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -22,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install mdBook
         run: |
@@ -36,20 +37,24 @@ jobs:
         run: mdbook build
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs/book
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    # Only this job talks to the Pages deployment API.
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least-privilege default for GITHUB_TOKEN. Only the jobs that push commits or
+# tags / publish a release elevate to contents: write below.
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,11 +18,14 @@ jobs:
     name: Auto-bump version
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    # Pushes the auto-bump commit back to main.
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
       sha: ${{ steps.bump.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -87,13 +92,13 @@ jobs:
             runner: macos-latest
             gnu_cross_toolchain: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.version-bump.outputs.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}
 
@@ -118,7 +123,7 @@ jobs:
           cd dist && tar czf ../recipe-runner-rs-${{ matrix.target }}.tar.gz *
           cd .. && sha256sum recipe-runner-rs-${{ matrix.target }}.tar.gz > recipe-runner-rs-${{ matrix.target }}.tar.gz.sha256
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: recipe-runner-rs-${{ matrix.target }}
           path: |
@@ -130,12 +135,15 @@ jobs:
     name: Create Release
     needs: [version-bump, build]
     runs-on: ubuntu-latest
+    # Pushes the version tag and creates the GitHub Release.
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.version-bump.outputs.sha }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
@@ -156,7 +164,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ needs.version-bump.outputs.version }}
           name: "recipe-runner-rs v${{ needs.version-bump.outputs.version }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,81 @@
+# cargo-deny configuration — supply-chain policy gate.
+#
+# Enforced in CI by the `security-audit` job (.github/workflows/ci.yml) via
+# `cargo deny check`, which runs all four checks below: advisories, bans,
+# licenses, and sources. Keep this file in sync with the dependency tree;
+# every entry that loosens a default carries a short justification.
+#
+# Schema reference: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Evaluate the dependency graph for the platforms we actually build and ship
+# (see release.yml build matrix). Platform-exclusive deps for other targets are
+# pruned, keeping the policy focused on code that can reach our binaries.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+]
+all-features = true
+
+[advisories]
+# Use the RustSec advisory database (default). Any security vulnerability fails
+# the check. Yanked crates are treated as errors so a compromised/withdrawn
+# release cannot silently remain in Cargo.lock.
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+# No advisories are currently ignored. If a transitive advisory ever needs a
+# temporary waiver, add it here with an explicit reason and a tracking issue,
+# e.g. { id = "RUSTSEC-XXXX-NNNN", reason = "...", }.
+ignore = []
+
+[licenses]
+# Allow-list of OSI/FSF-approved permissive (and permissive-data) licenses
+# present in the dependency tree. Every crate must resolve to at least one of
+# these. Verified against `cargo deny list` for the committed Cargo.lock.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "0BSD",
+    "Zlib",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+    "Unlicense",
+]
+confidence-threshold = 0.9
+# Per-crate exceptions for licenses we accept only for a specific dependency
+# rather than blanket-allowing across the whole tree.
+exceptions = [
+    # option-ext is MPL-2.0 (weak, file-level copyleft). It is a transitive
+    # dependency pulled in via dirs -> dirs-sys and is not modified by us, so
+    # the file-level copyleft obligation is satisfied without affecting our
+    # MIT-licensed sources.
+    { crate = "option-ext", allow = ["MPL-2.0"] },
+]
+
+[licenses.private]
+# This crate (recipe-runner-rs) is published, so do not skip workspace members.
+ignore = false
+
+[bans]
+# Duplicate versions are reported but not fatal — they are common and churny in
+# transitive trees, and blocking on them would create constant CI noise.
+multiple-versions = "warn"
+# Wildcard ("*") version requirements are forbidden: they undermine
+# reproducibility. None exist today; this keeps it that way.
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+# Only crates.io is permitted. Unknown registries or git sources fail the
+# check, preventing a dependency from being silently sourced from an
+# untrusted/unaudited location.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Supply-chain hardening for `amplihack-recipe-runner`

Hardens the repo's CI/CD supply chain using the proven Simard template
(rysweet/Simard #2472 / #2485 / #2487). Four focused control families:

### 1. SHA-pin every GitHub Action
All third-party actions across **ci.yml, release.yml, pages.yml, copilot-setup-steps.yml**
are pinned to a full 40-char commit SHA with a trailing version comment
(mutable tags/branches like `@v4`, `@stable`, `@v6` can be force-moved to
malicious code; immutable SHAs cannot). The generated `*.lock.yml`
guardian/bot-detection files were intentionally left untouched.

| Action | Pinned SHA (# tag) |
|---|---|
| actions/checkout | `34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`, `df4cb1c069e1874edd31b4311f1884172cec0e10 # v6` |
| dtolnay/rust-toolchain | `29eef336d9b2848a0b548edc03f92a220660cdb8 # stable` |
| actions/cache | `0057852bfaa89a56745cba8c7296529d2fc39830 # v4` |
| Swatinem/rust-cache | `e18b497796c12c097a38f9edb9d0641fb99eee32 # v2` |
| actions/upload-artifact | `ea165f8d65b6e75b540449e92b4886f43607fa02 # v4` |
| actions/download-artifact | `d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4` |
| actions/configure-pages | `983d7736d9b0ae728b81ab479565c72886d7745b # v5` |
| actions/upload-pages-artifact | `56afc609e74202658d3ffba0e8f6dda462b719fa # v3` |
| actions/deploy-pages | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4` |
| softprops/action-gh-release | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2` |

(`github/gh-aw/actions/setup-cli` was already SHA-pinned.)

### 2. Least-privilege `GITHUB_TOKEN`
- **ci.yml**: added top-level `permissions: { contents: read }` (was absent → implicit broad token).
- **release.yml**: top-level lowered `contents: write` → `contents: read`; `contents: write` granted only to the `version-bump` (pushes bump commit) and `release` (pushes tag + publishes release) jobs. The `build` job now runs read-only.
- **pages.yml**: `pages: write` / `id-token: write` moved off the top level onto the `deploy` job alone; `build` job is read-only.
- **copilot-setup-steps.yml**: added explicit deny-all `permissions: {}` default (job keeps its existing `contents: read`).

### 3. Locked / pinned dependencies
- `Cargo.lock` is committed and not git-ignored (verified).
- No git dependencies in `Cargo.toml` (all crates.io, version-constrained) — nothing to rev-pin.
- Tool installs pinned to exact versions with `--locked`: `cargo-audit 0.22.2`, `cargo-deny 0.19.9`, `cargo-tarpaulin 0.36.0` (an unpinned `cargo install` is itself a supply-chain vector).

### 4. Green dependency-audit gate
- Existing `cargo audit` step retained (now version-pinned install).
- **Added `cargo deny check`** to the `security-audit` job with a committed, fully-commented **`deny.toml`** covering all four checks: **advisories + bans + licenses + sources**.
  - licenses: explicit permissive allow-list verified against the committed lockfile, with a documented `MPL-2.0` exception scoped to the single transitive `option-ext` crate.
  - sources: only crates.io permitted (`unknown-registry`/`unknown-git` = deny).
- **Resolved RUSTSEC-2026-0190** (anyhow `Error::downcast_mut` unsoundness) by bumping `anyhow 1.0.102 → 1.0.103` in `Cargo.lock`. `cargo audit` is now fully clean (zero advisories). No advisories required a manual-review waiver.

---

## Merge-ready evidence

**1. QA / validation.** `gadugi-test` is a Simard-internal harness and is not present in this repo; this change adds **no new runtime/CLI/behavioral surface** to script. The correct, deterministic QA for supply-chain hardening is the repo's own gate suite, all run locally and green:

```
cargo audit                     → 0 advisories (clean)
cargo deny check                → advisories ok, bans ok, licenses ok, sources ok
cargo fmt --check               → ok
cargo clippy --all-targets -D warnings → ok
cargo build --release           → ok
cargo test --all-targets        → 360+ tests passed, 0 failed
actionlint (4 workflows)        → no new findings (only pre-existing shellcheck
                                  style nits in unmodified release.yml scripts)
```

**2. Docs / changed surfaces.** All changed surfaces are **internal CI/policy infrastructure** — no user-facing CLI, API, or runtime behavior changes:
`.github/workflows/{ci,release,pages,copilot-setup-steps}.yml`, `deny.toml`, `Cargo.lock`. `deny.toml` is self-documenting via inline comments. Internal-only justification applies; no end-user docs require updates.

**3. Quality-audit cycles (≥3 SEEK→VALIDATE→FIX, ended clean).**
- **Cycle 1** — SEEK: baseline scan found unpinned actions, missing `permissions` in ci.yml, unpinned tool installs, no cargo-deny. FIX: pinned all actions, added least-privilege permissions, pinned installs, added cargo-deny + deny.toml.
- **Cycle 2** — VALIDATE: `cargo audit` surfaced RUSTSEC-2026-0190 (anyhow unsound). FIX: bumped anyhow → 1.0.103; re-audit clean.
- **Cycle 3** — VALIDATE: `cargo deny check` → tuned license allow-list (scoped MPL-2.0 exception); re-ran the full gate suite (audit, deny, fmt, clippy, build, test, actionlint) — all green. Final cycle clean: **zero critical/high, zero medium correctness/security findings.**

**4. CI — 100% green.** The **CI** workflow run for this PR is **success**, all six jobs green:
<https://github.com/rysweet/amplihack-recipe-runner/actions/runs/28400864475>

| Job | Result |
|---|---|
| Build & Test | ✅ pass (2m19s) |
| Clippy | ✅ pass |
| Format | ✅ pass |
| Validate Self-Building Recipe | ✅ pass |
| **Security Audit** (cargo audit + **cargo deny check**) | ✅ pass (5m16s) |
| Code Coverage (pinned tarpaulin, ≥60% gate) | ✅ pass (5m21s) |

`GitGuardian Security Checks` and `copilot-setup-steps` also pass.

**6. Focused diff.** 6 files, exclusively supply-chain hardening; no unrelated edits:

```
 .github/workflows/ci.yml                  | 45 +++++++++++-------
 .github/workflows/copilot-setup-steps.yml |  5 +-
 .github/workflows/pages.yml               | 17 +++++---
 .github/workflows/release.yml             | 26 +++++++----
 Cargo.lock                                |  4 +- (anyhow patch bump only)
 deny.toml                                 | 81 +++++++++++++++++++++ (new)
```

---

### ⚠️ Known unrelated red check: `Repo Guardian` → `agent`

The `agent` job of the generated **Repo Guardian** agentic workflow
(`repo-guardian.lock.yml`) reports failure on this PR. This is **pre-existing,
environmental, and unrelated to this change**:

- Root cause (from the job log): the Claude Code CLI it invokes is
  unauthenticated — `api_error_status: 401`, `result: "Not logged in"`,
  `ANTHROPIC_AUTH_TOKEN is placeholder value`, `apiKeySource: none`. It is a
  missing-secret configuration issue in the repo's agentic guardian, not a code
  problem in this PR.
- It fails the same way on most recent PRs (4 of the last 5, independent of
  content), confirming it is not triggered by this diff.
- It is **not a required status check** (branch protection
  `required_status_checks: null`) and therefore does not gate merge.
- The file is a generated `*.lock.yml` guardian artifact, explicitly out of
  scope for this change (left untouched).

No supply-chain advisory requires manual operator review here — `cargo audit`
and `cargo deny check` are both clean/green.
